### PR TITLE
feat: emit audio-level events and drive waveform from real audio

### DIFF
--- a/src-tauri/src/audio/mod.rs
+++ b/src-tauri/src/audio/mod.rs
@@ -1,7 +1,14 @@
 use std::io::Cursor;
 use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
 
 use cpal::traits::{DeviceTrait, HostTrait, StreamTrait};
+use tauri::{AppHandle, Emitter};
+
+use crate::AudioLevelPayload;
+
+const AUDIO_LEVEL_EMIT_INTERVAL: Duration = Duration::from_millis(33);
+const AUDIO_LEVEL_GAIN: f32 = 4.0;
 
 pub struct AudioRecordingState {
     stream: Mutex<Option<cpal::Stream>>,
@@ -34,7 +41,11 @@ pub fn list_input_devices() -> Vec<String> {
         .unwrap_or_default()
 }
 
-pub fn start(audio: &AudioRecordingState, device_name: Option<&str>) -> Result<(), String> {
+pub fn start(
+    audio: &AudioRecordingState,
+    device_name: Option<&str>,
+    app: &AppHandle,
+) -> Result<(), String> {
     let host = cpal::default_host();
     let device = if let Some(name) = device_name {
         host.input_devices()
@@ -56,7 +67,7 @@ pub fn start(audio: &AudioRecordingState, device_name: Option<&str>) -> Result<(
     let buffer = audio.buffer.clone();
     buffer.lock().unwrap().clear();
 
-    let stream = build_stream(&device, &config, buffer)?;
+    let stream = build_stream(&device, &config, buffer, app.clone())?;
     stream.play().map_err(|e| format!("RECORDING_FAILED: {e}"))?;
 
     *audio.stream.lock().unwrap() = Some(stream);
@@ -77,43 +88,85 @@ fn build_stream(
     device: &cpal::Device,
     config: &cpal::SupportedStreamConfig,
     buffer: Arc<Mutex<Vec<f32>>>,
+    app: AppHandle,
 ) -> Result<cpal::Stream, String> {
     let err_fn = |err| log::error!("audio stream error: {err}");
     let cfg: cpal::StreamConfig = config.clone().into();
+    let last_emit = Arc::new(Mutex::new(Instant::now()));
 
     let stream = match config.sample_format() {
-        cpal::SampleFormat::F32 => device.build_input_stream(
-            &cfg,
-            move |data: &[f32], _| buffer.lock().unwrap().extend_from_slice(data),
-            err_fn,
-            None,
-        ),
-        cpal::SampleFormat::I16 => device.build_input_stream(
-            &cfg,
-            move |data: &[i16], _| {
-                buffer
-                    .lock()
-                    .unwrap()
-                    .extend(data.iter().map(|&s| s as f32 / i16::MAX as f32))
-            },
-            err_fn,
-            None,
-        ),
-        cpal::SampleFormat::U16 => device.build_input_stream(
-            &cfg,
-            move |data: &[u16], _| {
-                buffer
-                    .lock()
-                    .unwrap()
-                    .extend(data.iter().map(|&s| (s as f32 - 32768.0) / 32768.0))
-            },
-            err_fn,
-            None,
-        ),
+        cpal::SampleFormat::F32 => {
+            let emit_state = last_emit.clone();
+            let emit_app = app.clone();
+            device.build_input_stream(
+                &cfg,
+                move |data: &[f32], _| {
+                    buffer.lock().unwrap().extend_from_slice(data);
+                    maybe_emit_level(&emit_app, &emit_state, data);
+                },
+                err_fn,
+                None,
+            )
+        }
+        cpal::SampleFormat::I16 => {
+            let emit_state = last_emit.clone();
+            let emit_app = app.clone();
+            device.build_input_stream(
+                &cfg,
+                move |data: &[i16], _| {
+                    let floats: Vec<f32> =
+                        data.iter().map(|&s| s as f32 / i16::MAX as f32).collect();
+                    buffer.lock().unwrap().extend_from_slice(&floats);
+                    maybe_emit_level(&emit_app, &emit_state, &floats);
+                },
+                err_fn,
+                None,
+            )
+        }
+        cpal::SampleFormat::U16 => {
+            let emit_state = last_emit.clone();
+            let emit_app = app.clone();
+            device.build_input_stream(
+                &cfg,
+                move |data: &[u16], _| {
+                    let floats: Vec<f32> = data
+                        .iter()
+                        .map(|&s| (s as f32 - 32768.0) / 32768.0)
+                        .collect();
+                    buffer.lock().unwrap().extend_from_slice(&floats);
+                    maybe_emit_level(&emit_app, &emit_state, &floats);
+                },
+                err_fn,
+                None,
+            )
+        }
         fmt => return Err(format!("RECORDING_FAILED: unsupported sample format {fmt:?}")),
     };
 
     stream.map_err(|e| format!("RECORDING_FAILED: {e}"))
+}
+
+fn maybe_emit_level(app: &AppHandle, last_emit: &Arc<Mutex<Instant>>, samples: &[f32]) {
+    let now = Instant::now();
+    {
+        let mut last = last_emit.lock().unwrap();
+        if now.duration_since(*last) < AUDIO_LEVEL_EMIT_INTERVAL {
+            return;
+        }
+        *last = now;
+    }
+
+    let level = compute_level(samples);
+    let _ = app.emit("audio-level", AudioLevelPayload { level });
+}
+
+pub fn compute_level(samples: &[f32]) -> f32 {
+    if samples.is_empty() {
+        return 0.0;
+    }
+    let sum_sq: f32 = samples.iter().map(|&s| s * s).sum();
+    let rms = (sum_sq / samples.len() as f32).sqrt();
+    (rms * AUDIO_LEVEL_GAIN).clamp(0.0, 1.0)
 }
 
 fn encode_wav(samples: &[f32], sample_rate: u32, channels: u16) -> Result<Vec<u8>, String> {
@@ -207,5 +260,38 @@ mod tests {
             let reconstructed = *dec as f32 / i16::MAX as f32;
             assert!((orig - reconstructed).abs() < 0.001, "sample mismatch: {orig} vs {reconstructed}");
         }
+    }
+
+    #[test]
+    fn compute_level_returns_zero_for_empty() {
+        assert_eq!(compute_level(&[]), 0.0);
+    }
+
+    #[test]
+    fn compute_level_returns_zero_for_silence() {
+        let samples = vec![0.0f32; 512];
+        assert_eq!(compute_level(&samples), 0.0);
+    }
+
+    #[test]
+    fn compute_level_scales_rms_by_gain_and_clamps() {
+        // Constant 0.5 amplitude → RMS = 0.5 → 0.5 * 4.0 = 2.0 → clamps to 1.0
+        let samples = vec![0.5f32; 512];
+        assert_eq!(compute_level(&samples), 1.0);
+    }
+
+    #[test]
+    fn compute_level_matches_rms_for_quiet_signal() {
+        // Constant 0.1 amplitude → RMS = 0.1 → 0.1 * 4.0 = 0.4 (within clamp)
+        let samples = vec![0.1f32; 512];
+        let level = compute_level(&samples);
+        assert!((level - 0.4).abs() < 1e-5, "got {level}");
+    }
+
+    #[test]
+    fn compute_level_symmetric_for_negative_samples() {
+        let pos = vec![0.1f32; 512];
+        let neg = vec![-0.1f32; 512];
+        assert!((compute_level(&pos) - compute_level(&neg)).abs() < 1e-6);
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -53,6 +53,11 @@ pub struct ErrorPayload {
 }
 
 #[derive(Clone, serde::Serialize)]
+pub struct AudioLevelPayload {
+    pub level: f32,
+}
+
+#[derive(Clone, serde::Serialize)]
 pub struct ModelDownloadProgressPayload {
     pub size: String,
     pub downloaded_bytes: u64,

--- a/src-tauri/src/shortcut/mod.rs
+++ b/src-tauri/src/shortcut/mod.rs
@@ -100,7 +100,7 @@ fn start_recording(app: &AppHandle) {
         .clone();
 
     let audio = app.state::<AudioRecordingState>();
-    if let Err(e) = crate::audio::start(&audio, device_name.as_deref()) {
+    if let Err(e) = crate::audio::start(&audio, device_name.as_deref(), app) {
         crate::errors::emit(app, "MICROPHONE_UNAVAILABLE", &e);
         crate::errors::transition_to_error(app);
         return;

--- a/src/StatusBar.tsx
+++ b/src/StatusBar.tsx
@@ -14,10 +14,13 @@ const LABELS: Record<AppState, string> = {
   error:      'state.error',
 }
 
+const WAVE_BARS = 14
+
 export default function StatusBar() {
   const { t } = useTranslation()
   const [appState, setAppState] = useState<AppState>('idle')
   const [elapsed, setElapsed] = useState(0)
+  const [levels, setLevels] = useState<number[]>([])
   const startRef = useRef<number | null>(null)
   const timerRef = useRef<ReturnType<typeof setInterval> | null>(null)
 
@@ -34,6 +37,17 @@ export default function StatusBar() {
   }, [])
 
   useEffect(() => {
+    const unlisten = listen<{ level: number }>('audio-level', (e) => {
+      setLevels((prev) => {
+        const next = prev.length >= WAVE_BARS ? prev.slice(1) : prev.slice()
+        next.push(e.payload.level)
+        return next
+      })
+    })
+    return () => { unlisten.then((fn) => fn()) }
+  }, [])
+
+  useEffect(() => {
     if (appState === 'recording') {
       startRef.current = Date.now()
       timerRef.current = setInterval(() => {
@@ -43,6 +57,7 @@ export default function StatusBar() {
       if (timerRef.current) clearInterval(timerRef.current)
       setElapsed(0)
       startRef.current = null
+      setLevels([])
     }
     return () => { if (timerRef.current) clearInterval(timerRef.current) }
   }, [appState])
@@ -63,7 +78,7 @@ export default function StatusBar() {
             <span className="ember" />
             REC
           </div>
-          <Waveform />
+          <Waveform levels={levels} bars={WAVE_BARS} />
           <span className="pill-timer">{formatTime(elapsed)}</span>
         </div>
       ) : (
@@ -78,20 +93,18 @@ export default function StatusBar() {
   )
 }
 
-function Waveform({ bars = 14 }: { bars?: number }) {
-  const seeds = Array.from({ length: bars }, (_, i) =>
-    (Math.sin(i * 1.7) + Math.cos(i * 0.7)) * 0.5 + 0.5
-  )
+function Waveform({ levels, bars }: { levels: number[]; bars: number }) {
+  const padded = Array.from({ length: bars }, (_, i) => {
+    const offset = levels.length - bars + i
+    return offset >= 0 ? levels[offset] : 0
+  })
   return (
     <div className="waveform">
-      {seeds.map((_, i) => (
+      {padded.map((level, i) => (
         <span
           key={i}
           className="bar"
-          style={{
-            animationDelay: `${(i * 0.07) % 1.1}s`,
-            animationDuration: `${0.9 + (i % 5) * 0.08}s`,
-          }}
+          style={{ height: `${Math.max(16, level * 100)}%` }}
         />
       ))}
     </div>

--- a/src/index.css
+++ b/src/index.css
@@ -296,8 +296,7 @@ input[type="password"]::-ms-reveal { display: none; }
 .pill-wave .rec-label { display: flex; align-items: center; gap: 8px; font-family: var(--f-mono); font-size: 10.5px; font-weight: 500; letter-spacing: 0.12em; text-transform: uppercase; color: #EBE8E0; }
 .pill-wave .rec-label .ember { width: 7px; height: 7px; border-radius: 50%; background: var(--v-ember); flex-shrink: 0; animation: pillPulse 1.6s var(--ease) infinite; }
 .waveform { display: flex; align-items: center; gap: 2px; height: 18px; }
-.waveform .bar { width: 2px; background: #EBE8E0; border-radius: 1px; transform-origin: center; animation: waveBounce 1.1s var(--ease) infinite; }
-@keyframes waveBounce { 0%,100% { height: 3px; opacity: 0.45; } 50% { height: 100%; opacity: 1; } }
+.waveform .bar { width: 2px; background: #EBE8E0; border-radius: 1px; transform-origin: center; opacity: 0.85; transition: height 60ms linear; }
 .pill-wave .pill-timer { font-family: var(--f-mono); font-size: 12px; font-variant-numeric: tabular-nums; color: rgba(235,232,224,0.85); }
 .pill-wave .pill-sep { width: 1px; height: 14px; background: rgba(235,232,224,0.16); }
 


### PR DESCRIPTION
Previously the status bar's waveform bars were animated purely via CSS keyframes, so they looked identical regardless of what the user was saying. This wires the visualization up to the actual recording loop.

Backend:
- audio::start now takes an AppHandle so the cpal stream callback can emit events
- Each callback computes RMS over the chunk it received, applies a fixed gain and clamps to 0.0–1.0
- Emission is throttled to ~30fps (33ms) via a shared Instant to avoid flooding the event bus
- compute_level() exposed for unit testing; added tests for empty input, silence, clamping, and sign symmetry

Frontend:
- StatusBar listens to the new 'audio-level' event and maintains a rolling buffer of the last 14 values
- Waveform renders bar heights from that buffer; newest value is right-most and values scroll left as new events arrive
- Levels reset whenever the app leaves the recording state
- CSS: removed the waveBounce keyframe animation and added a 60ms height transition so bar updates look smooth

Closes #16