### PR TITLE
feat: aggregate usage stats from history and render real data

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -36,6 +36,7 @@ whisper-rs = "0.16"
 tokio = { version = "1", features = ["fs", "rt"] }
 base64 = "0.22"
 regex = "1"
+chrono = { version = "0.4", default-features = false, features = ["clock"] }
 
 [dev-dependencies]
 tempfile = "3"

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -267,6 +267,13 @@ pub fn get_history(app: tauri::AppHandle) -> Result<Vec<crate::storage::HistoryE
 }
 
 #[tauri::command]
+pub fn get_stats(app: tauri::AppHandle) -> Result<crate::stats::StatsSummary, String> {
+    let history = crate::storage::load_history(&app)?;
+    let now_ms = chrono::Local::now().timestamp_millis();
+    Ok(crate::stats::aggregate(&history, now_ms))
+}
+
+#[tauri::command]
 pub fn clear_history(app: tauri::AppHandle) -> Result<(), String> {
     crate::storage::clear_history(&app)
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -7,6 +7,7 @@ pub mod hotkey;
 pub mod keychain;
 pub mod local_transcription;
 pub mod shortcut;
+pub mod stats;
 pub mod storage;
 pub mod transcription;
 
@@ -170,6 +171,7 @@ pub fn run() {
             commands::set_autostart,
             commands::get_history,
             commands::clear_history,
+            commands::get_stats,
             commands::set_window_theme,
             commands::list_audio_devices,
             commands::set_audio_device,

--- a/src-tauri/src/stats/mod.rs
+++ b/src-tauri/src/stats/mod.rs
@@ -310,8 +310,9 @@ mod tests {
         assert_eq!(s.providers[0].name, "groq");
         assert_eq!(s.providers[0].count, 3);
         assert!((s.providers[0].share - 0.6).abs() < 1e-9);
-        assert_eq!(s.providers[1].name, "local");
-        assert_eq!(s.providers[2].name, "deepgram");
+        // Tie on count=1 → alphabetical order
+        assert_eq!(s.providers[1].name, "deepgram");
+        assert_eq!(s.providers[2].name, "local");
     }
 
     #[test]

--- a/src-tauri/src/stats/mod.rs
+++ b/src-tauri/src/stats/mod.rs
@@ -1,0 +1,366 @@
+use std::collections::HashMap;
+
+use chrono::{DateTime, Datelike, Duration, Local, NaiveDate, Utc};
+
+use crate::storage::HistoryEntry;
+
+const TYPING_WPM: f64 = 55.0;
+const ACTIVITY_DAYS: usize = 30;
+
+#[derive(Debug, Clone, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ProviderStat {
+    pub name: String,
+    pub count: u64,
+    pub share: f64,
+}
+
+#[derive(Debug, Clone, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct StatsSummary {
+    pub total_words: u64,
+    pub total_duration_secs: f64,
+    pub avg_wpm: f64,
+    pub words_today: u64,
+    pub words_this_week: u64,
+    pub words_last_week: u64,
+    pub minutes_saved_today: f64,
+    pub minutes_saved_total: f64,
+    pub longest_session_secs: f32,
+    pub longest_session_timestamp_ms: Option<u64>,
+    pub ai_polish_rate: f64,
+    pub providers: Vec<ProviderStat>,
+    pub activity_30d: Vec<u64>,
+}
+
+pub fn aggregate(history: &[HistoryEntry], now_ms: i64) -> StatsSummary {
+    let now_local: DateTime<Local> = DateTime::<Utc>::from_timestamp_millis(now_ms)
+        .unwrap_or_default()
+        .with_timezone(&Local);
+    let today = now_local.date_naive();
+    let this_monday = monday_of(today);
+    let last_monday = this_monday - Duration::days(7);
+    let activity_start = today - Duration::days((ACTIVITY_DAYS - 1) as i64);
+
+    let mut total_words: u64 = 0;
+    let mut total_duration_secs: f64 = 0.0;
+    let mut words_today: u64 = 0;
+    let mut words_this_week: u64 = 0;
+    let mut words_last_week: u64 = 0;
+    let mut minutes_saved_today: f64 = 0.0;
+    let mut minutes_saved_total: f64 = 0.0;
+    let mut longest: Option<(f32, u64)> = None;
+    let mut enhanced_count: u64 = 0;
+    let mut provider_counts: HashMap<String, u64> = HashMap::new();
+    let mut activity = vec![0u64; ACTIVITY_DAYS];
+
+    for entry in history {
+        total_words += entry.word_count as u64;
+        total_duration_secs += entry.duration_secs as f64;
+        if entry.enhanced {
+            enhanced_count += 1;
+        }
+        *provider_counts.entry(entry.provider.clone()).or_insert(0) += 1;
+
+        let is_new_longest = match &longest {
+            None => true,
+            Some((d, _)) => entry.duration_secs > *d,
+        };
+        if is_new_longest {
+            longest = Some((entry.duration_secs, entry.timestamp_ms));
+        }
+
+        let saved_minutes = time_saved_minutes(entry.word_count, entry.duration_secs as f64);
+        minutes_saved_total += saved_minutes;
+
+        let Some(entry_date) = local_date(entry.timestamp_ms as i64) else {
+            continue;
+        };
+
+        if entry_date == today {
+            words_today += entry.word_count as u64;
+            minutes_saved_today += saved_minutes;
+        }
+        if entry_date >= this_monday && entry_date <= today {
+            words_this_week += entry.word_count as u64;
+        } else if entry_date >= last_monday && entry_date < this_monday {
+            words_last_week += entry.word_count as u64;
+        }
+        if entry_date >= activity_start && entry_date <= today {
+            let idx = (entry_date - activity_start).num_days() as usize;
+            if idx < ACTIVITY_DAYS {
+                activity[idx] += entry.word_count as u64;
+            }
+        }
+    }
+
+    let total = history.len() as f64;
+    let mut providers: Vec<ProviderStat> = provider_counts
+        .into_iter()
+        .map(|(name, count)| ProviderStat {
+            share: if total > 0.0 { count as f64 / total } else { 0.0 },
+            count,
+            name,
+        })
+        .collect();
+    providers.sort_by(|a, b| b.count.cmp(&a.count).then_with(|| a.name.cmp(&b.name)));
+
+    let avg_wpm = if total_duration_secs > 0.0 {
+        (total_words as f64) / (total_duration_secs / 60.0)
+    } else {
+        0.0
+    };
+
+    let ai_polish_rate = if history.is_empty() {
+        0.0
+    } else {
+        enhanced_count as f64 / history.len() as f64
+    };
+
+    let (longest_session_secs, longest_session_timestamp_ms) = match longest {
+        Some((d, ts)) => (d, Some(ts)),
+        None => (0.0, None),
+    };
+
+    StatsSummary {
+        total_words,
+        total_duration_secs,
+        avg_wpm,
+        words_today,
+        words_this_week,
+        words_last_week,
+        minutes_saved_today,
+        minutes_saved_total,
+        longest_session_secs,
+        longest_session_timestamp_ms,
+        ai_polish_rate,
+        providers,
+        activity_30d: activity,
+    }
+}
+
+fn local_date(ms: i64) -> Option<NaiveDate> {
+    DateTime::<Utc>::from_timestamp_millis(ms).map(|dt| dt.with_timezone(&Local).date_naive())
+}
+
+fn monday_of(d: NaiveDate) -> NaiveDate {
+    d - Duration::days(d.weekday().num_days_from_monday() as i64)
+}
+
+fn time_saved_minutes(word_count: u32, duration_secs: f64) -> f64 {
+    let typing_secs = (word_count as f64 / TYPING_WPM) * 60.0;
+    let saved = typing_secs - duration_secs;
+    if saved > 0.0 {
+        saved / 60.0
+    } else {
+        0.0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn entry(ts_ms: u64, words: u32, duration: f32, enhanced: bool, provider: &str) -> HistoryEntry {
+        HistoryEntry {
+            id: format!("id-{ts_ms}"),
+            timestamp_ms: ts_ms,
+            text: String::new(),
+            enhanced,
+            duration_secs: duration,
+            word_count: words,
+            provider: provider.into(),
+        }
+    }
+
+    fn now_ms() -> i64 {
+        Local::now().timestamp_millis()
+    }
+
+    fn day_ms() -> u64 {
+        86_400_000
+    }
+
+    #[test]
+    fn aggregate_empty_history_returns_zeros() {
+        let s = aggregate(&[], now_ms());
+        assert_eq!(s.total_words, 0);
+        assert_eq!(s.total_duration_secs, 0.0);
+        assert_eq!(s.avg_wpm, 0.0);
+        assert_eq!(s.words_today, 0);
+        assert_eq!(s.ai_polish_rate, 0.0);
+        assert_eq!(s.longest_session_timestamp_ms, None);
+        assert_eq!(s.activity_30d.len(), ACTIVITY_DAYS);
+        assert!(s.providers.is_empty());
+    }
+
+    #[test]
+    fn aggregate_sums_totals() {
+        let now = now_ms();
+        let hist = vec![
+            entry(now as u64, 100, 30.0, false, "groq"),
+            entry(now as u64 - 3_600_000, 50, 20.0, true, "groq"),
+        ];
+        let s = aggregate(&hist, now);
+        assert_eq!(s.total_words, 150);
+        assert!((s.total_duration_secs - 50.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn aggregate_avg_wpm_from_totals() {
+        let now = now_ms();
+        // 100 words in 60s = 100 wpm
+        let hist = vec![entry(now as u64, 100, 60.0, false, "groq")];
+        let s = aggregate(&hist, now);
+        assert!((s.avg_wpm - 100.0).abs() < 1e-6);
+    }
+
+    #[test]
+    fn aggregate_avg_wpm_zero_when_no_duration() {
+        let s = aggregate(&[entry(now_ms() as u64, 50, 0.0, false, "groq")], now_ms());
+        assert_eq!(s.avg_wpm, 0.0);
+    }
+
+    #[test]
+    fn aggregate_words_today_counts_recent_only() {
+        let now = now_ms();
+        let hist = vec![
+            entry(now as u64 - 3_600_000, 10, 5.0, false, "groq"), // ~1h ago
+            entry(now as u64 - 10 * day_ms() as u64, 30, 10.0, false, "groq"), // 10 days ago
+        ];
+        let s = aggregate(&hist, now);
+        assert_eq!(s.words_today, 10);
+    }
+
+    #[test]
+    fn aggregate_words_this_week_includes_today() {
+        let now = now_ms();
+        let hist = vec![entry(now as u64 - 3_600_000, 42, 20.0, false, "groq")];
+        let s = aggregate(&hist, now);
+        assert_eq!(s.words_this_week, 42);
+        assert_eq!(s.words_last_week, 0);
+    }
+
+    #[test]
+    fn aggregate_words_last_week_captures_seven_days_ago() {
+        let now = now_ms();
+        // 7 days ago is always in "last week" relative to today (same weekday, previous ISO week)
+        let hist = vec![entry(now as u64 - 7 * day_ms(), 25, 10.0, false, "groq")];
+        let s = aggregate(&hist, now);
+        assert_eq!(s.words_last_week, 25);
+        assert_eq!(s.words_this_week, 0);
+    }
+
+    #[test]
+    fn aggregate_time_saved_positive_for_fast_dictation() {
+        let now = now_ms();
+        // 55 words in 30s = 110 wpm → typing-at-55-wpm would take 60s → saved 30s = 0.5 min
+        let hist = vec![entry(now as u64, 55, 30.0, false, "groq")];
+        let s = aggregate(&hist, now);
+        assert!((s.minutes_saved_total - 0.5).abs() < 1e-9);
+        assert!((s.minutes_saved_today - 0.5).abs() < 1e-9);
+    }
+
+    #[test]
+    fn aggregate_time_saved_floors_at_zero_for_slow_dictation() {
+        let now = now_ms();
+        // 10 words in 60s = 10 wpm, way below typing baseline → saved = 0
+        let hist = vec![entry(now as u64, 10, 60.0, false, "groq")];
+        let s = aggregate(&hist, now);
+        assert_eq!(s.minutes_saved_total, 0.0);
+    }
+
+    #[test]
+    fn aggregate_longest_session_tracked() {
+        let now = now_ms();
+        let hist = vec![
+            entry(now as u64, 10, 5.0, false, "groq"),
+            entry(now as u64 - 1000, 20, 42.0, false, "groq"),
+            entry(now as u64 - 2000, 30, 18.0, false, "groq"),
+        ];
+        let s = aggregate(&hist, now);
+        assert!((s.longest_session_secs - 42.0).abs() < 1e-6);
+        assert_eq!(s.longest_session_timestamp_ms, Some(now as u64 - 1000));
+    }
+
+    #[test]
+    fn aggregate_ai_polish_rate() {
+        let now = now_ms();
+        let hist = vec![
+            entry(now as u64, 10, 5.0, true, "groq"),
+            entry(now as u64, 10, 5.0, false, "groq"),
+            entry(now as u64, 10, 5.0, true, "groq"),
+            entry(now as u64, 10, 5.0, true, "groq"),
+        ];
+        let s = aggregate(&hist, now);
+        assert!((s.ai_polish_rate - 0.75).abs() < 1e-9);
+    }
+
+    #[test]
+    fn aggregate_providers_sorted_by_count_desc() {
+        let now = now_ms();
+        let hist = vec![
+            entry(now as u64, 10, 5.0, false, "groq"),
+            entry(now as u64, 10, 5.0, false, "local"),
+            entry(now as u64, 10, 5.0, false, "groq"),
+            entry(now as u64, 10, 5.0, false, "groq"),
+            entry(now as u64, 10, 5.0, false, "deepgram"),
+        ];
+        let s = aggregate(&hist, now);
+        assert_eq!(s.providers[0].name, "groq");
+        assert_eq!(s.providers[0].count, 3);
+        assert!((s.providers[0].share - 0.6).abs() < 1e-9);
+        assert_eq!(s.providers[1].name, "local");
+        assert_eq!(s.providers[2].name, "deepgram");
+    }
+
+    #[test]
+    fn aggregate_activity_30d_has_30_buckets() {
+        let s = aggregate(&[], now_ms());
+        assert_eq!(s.activity_30d.len(), 30);
+    }
+
+    #[test]
+    fn aggregate_activity_30d_today_is_last_bucket() {
+        let now = now_ms();
+        let hist = vec![entry(now as u64 - 3_600_000, 17, 10.0, false, "groq")];
+        let s = aggregate(&hist, now);
+        assert_eq!(s.activity_30d[29], 17);
+        assert_eq!(s.activity_30d[28], 0);
+    }
+
+    #[test]
+    fn aggregate_activity_30d_excludes_older_than_30_days() {
+        let now = now_ms();
+        let hist = vec![entry(now as u64 - 40 * day_ms(), 99, 10.0, false, "groq")];
+        let s = aggregate(&hist, now);
+        assert!(s.activity_30d.iter().all(|&c| c == 0));
+    }
+
+    #[test]
+    fn monday_of_monday_returns_self() {
+        // 2026-04-20 is a Monday
+        let d = NaiveDate::from_ymd_opt(2026, 4, 20).unwrap();
+        assert_eq!(monday_of(d), d);
+    }
+
+    #[test]
+    fn monday_of_sunday_returns_previous_monday() {
+        // 2026-04-26 is a Sunday → Monday 2026-04-20
+        let sunday = NaiveDate::from_ymd_opt(2026, 4, 26).unwrap();
+        let monday = NaiveDate::from_ymd_opt(2026, 4, 20).unwrap();
+        assert_eq!(monday_of(sunday), monday);
+    }
+
+    #[test]
+    fn time_saved_minutes_positive_when_faster_than_baseline() {
+        // 110 words in 30s (220 wpm) — baseline typing would take 120s → saved 90s = 1.5 min
+        let saved = time_saved_minutes(110, 30.0);
+        assert!((saved - 1.5).abs() < 1e-9);
+    }
+
+    #[test]
+    fn time_saved_minutes_zero_when_slower_than_baseline() {
+        assert_eq!(time_saved_minutes(5, 60.0), 0.0);
+    }
+}

--- a/src/pages/StatsPage.tsx
+++ b/src/pages/StatsPage.tsx
@@ -1,31 +1,92 @@
-// Stats page — usage insights.
-// Data is mock until backend exposes a stats API.
+import { useEffect, useState } from 'react'
+import { invoke } from '@tauri-apps/api/core'
 
-const DAYS = [12,8,18,22,30,14,45,24,38,42,28,52,35,48,30,22,56,41,38,62,44,52,38,68,54,48,42,38,55,49]
+type ProviderStat = { name: string; count: number; share: number }
+
+type StatsSummary = {
+  totalWords: number
+  totalDurationSecs: number
+  avgWpm: number
+  wordsToday: number
+  wordsThisWeek: number
+  wordsLastWeek: number
+  minutesSavedToday: number
+  minutesSavedTotal: number
+  longestSessionSecs: number
+  longestSessionTimestampMs: number | null
+  aiPolishRate: number
+  providers: ProviderStat[]
+  activity30d: number[]
+}
+
+const EMPTY: StatsSummary = {
+  totalWords: 0,
+  totalDurationSecs: 0,
+  avgWpm: 0,
+  wordsToday: 0,
+  wordsThisWeek: 0,
+  wordsLastWeek: 0,
+  minutesSavedToday: 0,
+  minutesSavedTotal: 0,
+  longestSessionSecs: 0,
+  longestSessionTimestampMs: null,
+  aiPolishRate: 0,
+  providers: [],
+  activity30d: Array(30).fill(0),
+}
+
+const PROVIDER_LABELS: Record<string, string> = {
+  groq: 'Groq',
+  local: 'Lokal',
+  deepgram: 'Deepgram',
+  openai: 'OpenAI',
+}
 
 export function StatsPage() {
-  const max = Math.max(...DAYS)
+  const [stats, setStats] = useState<StatsSummary>(EMPTY)
+
+  useEffect(() => {
+    invoke<StatsSummary>('get_stats').then(setStats).catch(() => setStats(EMPTY))
+  }, [])
+
+  const maxBar = Math.max(1, ...stats.activity30d)
+  const hoursSaved = stats.minutesSavedTotal / 60
 
   return (
     <div>
       <p className="page-eyebrow">statistiken</p>
-      <h1 className="page-title">3<em>.</em>284</h1>
-      <p className="page-sub">Wörter diktiert seit du VOCA benutzt. Ungefähr 42 Stunden gespartes Tippen.</p>
+      <h1 className="page-title">{formatGroupedNumber(stats.totalWords)}</h1>
+      <p className="page-sub">
+        {stats.totalWords === 0
+          ? 'Noch keine Aufnahmen. Starte dein erstes Diktat per Shortcut.'
+          : `Wörter diktiert seit du VOCA benutzt. Ungefähr ${formatHours(hoursSaved)} gespartes Tippen.`}
+      </p>
 
       <div className="stats-hero">
         <div className="cell">
           <div className="k">Diese Woche</div>
-          <div className="v">412<span className="unit">wörter</span></div>
-          <div className="trend">↗ +23% vs. letzte Woche</div>
+          <div className="v">
+            {formatGroupedNumber(stats.wordsThisWeek)}
+            <span className="unit">wörter</span>
+          </div>
+          <div className={weekTrendClass(stats.wordsThisWeek, stats.wordsLastWeek)}>
+            {formatWeekTrend(stats.wordsThisWeek, stats.wordsLastWeek)}
+          </div>
         </div>
         <div className="cell">
           <div className="k">Ø Geschwindigkeit</div>
-          <div className="v">168<span className="unit">wpm</span></div>
+          <div className="v">
+            {Math.round(stats.avgWpm)}
+            <span className="unit">wpm</span>
+          </div>
           <div className="trend down">~ Tippen: 55 wpm</div>
         </div>
         <div className="cell">
           <div className="k">Heute gespart</div>
-          <div className="v">78<span className="unit">min</span></div>
+          <div className="v">
+            {Math.round(stats.minutesSavedToday)}
+            <span className="unit">min</span>
+          </div>
           <div className="trend">vs. Tippen</div>
         </div>
       </div>
@@ -33,45 +94,94 @@ export function StatsPage() {
       <div className="chart-wrap">
         <div className="sec-head">Aktivität · letzte 30 Tage</div>
         <div className="chart" style={{ marginTop: 16 }}>
-          {DAYS.map((d, i) => (
+          {stats.activity30d.map((d, i) => (
             <div
               key={i}
-              className={`bar-col${i === DAYS.length - 1 ? ' today' : ''}`}
-              style={{ height: `${(d / max) * 100}%` }}
+              className={`bar-col${i === stats.activity30d.length - 1 ? ' today' : ''}`}
+              style={{ height: `${(d / maxBar) * 100}%` }}
             />
           ))}
         </div>
         <div className="chart-axis">
-          <span>vor 30</span><span>vor 20</span><span>vor 10</span><span>heute</span>
+          <span>vor 30</span>
+          <span>vor 20</span>
+          <span>vor 10</span>
+          <span>heute</span>
         </div>
       </div>
 
       <div className="stats-grid">
         <div className="cell">
           <div className="k">Längste Session</div>
-          <div className="v">4:32</div>
-          <div className="desc">14. April, beim Schreiben einer Spec-Note</div>
-        </div>
-        <div className="cell">
-          <div className="k">Häufigstes Ziel</div>
-          <div className="v">Slack</div>
-          <div className="desc">38% aller Transkripte</div>
+          <div className="v">{formatDuration(stats.longestSessionSecs)}</div>
+          <div className="desc">{formatLongestDate(stats.longestSessionTimestampMs)}</div>
         </div>
         <div className="cell">
           <div className="k">AI-Polish Quote</div>
-          <div className="v">64%</div>
+          <div className="v">{Math.round(stats.aiPolishRate * 100)}%</div>
           <div className="desc">Anteil mit Enhancement</div>
         </div>
         <div className="cell">
           <div className="k">Provider</div>
-          <div className="v" style={{ fontSize: 22 }}>Groq</div>
+          <div className="v" style={{ fontSize: 22 }}>
+            {stats.providers[0] ? providerLabel(stats.providers[0].name) : '—'}
+          </div>
           <div className="prov-mini">
-            <span className="chip">Groq<span className="pct"> · 82%</span></span>
-            <span className="chip">Lokal<span className="pct"> · 14%</span></span>
-            <span className="chip">Deepgram<span className="pct"> · 4%</span></span>
+            {stats.providers.length === 0 ? (
+              <span className="chip">Noch keine Daten</span>
+            ) : (
+              stats.providers.map((p) => (
+                <span key={p.name} className="chip">
+                  {providerLabel(p.name)}
+                  <span className="pct"> · {Math.round(p.share * 100)}%</span>
+                </span>
+              ))
+            )}
           </div>
         </div>
       </div>
     </div>
   )
+}
+
+function providerLabel(name: string): string {
+  return PROVIDER_LABELS[name] ?? name
+}
+
+function formatGroupedNumber(n: number): string {
+  return new Intl.NumberFormat('de-DE').format(n)
+}
+
+function formatHours(h: number): string {
+  if (h < 1) return `${Math.round(h * 60)} Minuten`
+  return `${h.toFixed(1).replace('.', ',')} Stunden`
+}
+
+function formatDuration(secs: number): string {
+  if (secs <= 0) return '0:00'
+  const total = Math.round(secs)
+  const m = Math.floor(total / 60)
+  const s = total % 60
+  return `${m}:${String(s).padStart(2, '0')}`
+}
+
+function formatLongestDate(ms: number | null): string {
+  if (!ms) return 'Noch keine Sessions'
+  const d = new Date(ms)
+  return new Intl.DateTimeFormat('de-DE', { day: 'numeric', month: 'long' }).format(d)
+}
+
+function formatWeekTrend(thisWeek: number, lastWeek: number): string {
+  if (lastWeek === 0) {
+    return thisWeek === 0 ? '—' : 'Start der Woche'
+  }
+  const delta = ((thisWeek - lastWeek) / lastWeek) * 100
+  const sign = delta >= 0 ? '+' : ''
+  const arrow = delta >= 0 ? '↗' : '↘'
+  return `${arrow} ${sign}${Math.round(delta)}% vs. letzte Woche`
+}
+
+function weekTrendClass(thisWeek: number, lastWeek: number): string {
+  if (lastWeek === 0 || thisWeek >= lastWeek) return 'trend'
+  return 'trend down'
 }


### PR DESCRIPTION
Adds a stats module that derives totals, weekly word counts, time-saved-vs-typing (55 wpm baseline), longest session, AI-polish rate, provider share, and a 30-day activity series from the history log. Boundaries use local timezone and ISO week (Monday start) so the numbers stay correct regardless of where the user is.

Wires a get_stats command and replaces the mock values on StatsPage with the real summary. Drops the "Häufigstes Ziel" card — tracking the insertion target app needs its own feature work and will follow in a separate issue.

Closes #17