### PR TITLE
feat: privacy settings with history and target-app tracking

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -38,6 +38,18 @@ base64 = "0.22"
 regex = "1"
 chrono = { version = "0.4", default-features = false, features = ["clock"] }
 
+[target.'cfg(target_os = "windows")'.dependencies]
+windows = { version = "0.58", features = [
+    "Win32_Foundation",
+    "Win32_System_Threading",
+    "Win32_UI_WindowsAndMessaging",
+] }
+
+[target.'cfg(target_os = "macos")'.dependencies]
+objc2 = "0.5"
+objc2-app-kit = { version = "0.2", features = ["NSWorkspace", "NSRunningApplication"] }
+objc2-foundation = "0.2"
+
 [dev-dependencies]
 tempfile = "3"
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -9,6 +9,7 @@ pub mod local_transcription;
 pub mod shortcut;
 pub mod stats;
 pub mod storage;
+pub mod target_app;
 pub mod transcription;
 
 use std::sync::{Arc, Mutex};

--- a/src-tauri/src/stats/mod.rs
+++ b/src-tauri/src/stats/mod.rs
@@ -17,6 +17,14 @@ pub struct ProviderStat {
 
 #[derive(Debug, Clone, serde::Serialize)]
 #[serde(rename_all = "camelCase")]
+pub struct TargetAppStat {
+    pub name: String,
+    pub count: u64,
+    pub share: f64,
+}
+
+#[derive(Debug, Clone, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct StatsSummary {
     pub total_words: u64,
     pub total_duration_secs: f64,
@@ -31,6 +39,8 @@ pub struct StatsSummary {
     pub ai_polish_rate: f64,
     pub providers: Vec<ProviderStat>,
     pub activity_30d: Vec<u64>,
+    pub top_target_app: Option<TargetAppStat>,
+    pub target_app_coverage: f64,
 }
 
 pub fn aggregate(history: &[HistoryEntry], now_ms: i64) -> StatsSummary {
@@ -52,6 +62,8 @@ pub fn aggregate(history: &[HistoryEntry], now_ms: i64) -> StatsSummary {
     let mut longest: Option<(f32, u64)> = None;
     let mut enhanced_count: u64 = 0;
     let mut provider_counts: HashMap<String, u64> = HashMap::new();
+    let mut target_app_counts: HashMap<String, u64> = HashMap::new();
+    let mut entries_with_target_app: u64 = 0;
     let mut activity = vec![0u64; ACTIVITY_DAYS];
 
     for entry in history {
@@ -61,6 +73,10 @@ pub fn aggregate(history: &[HistoryEntry], now_ms: i64) -> StatsSummary {
             enhanced_count += 1;
         }
         *provider_counts.entry(entry.provider.clone()).or_insert(0) += 1;
+        if let Some(target) = entry.target_app.as_deref().map(str::trim).filter(|s| !s.is_empty()) {
+            *target_app_counts.entry(target.to_owned()).or_insert(0) += 1;
+            entries_with_target_app += 1;
+        }
 
         let is_new_longest = match &longest {
             None => true,
@@ -122,6 +138,20 @@ pub fn aggregate(history: &[HistoryEntry], now_ms: i64) -> StatsSummary {
         None => (0.0, None),
     };
 
+    let top_target_app = target_app_counts
+        .into_iter()
+        .max_by(|a, b| a.1.cmp(&b.1).then_with(|| b.0.cmp(&a.0)))
+        .map(|(name, count)| TargetAppStat {
+            share: count as f64 / entries_with_target_app.max(1) as f64,
+            count,
+            name,
+        });
+    let target_app_coverage = if history.is_empty() {
+        0.0
+    } else {
+        entries_with_target_app as f64 / history.len() as f64
+    };
+
     StatsSummary {
         total_words,
         total_duration_secs,
@@ -136,6 +166,8 @@ pub fn aggregate(history: &[HistoryEntry], now_ms: i64) -> StatsSummary {
         ai_polish_rate,
         providers,
         activity_30d: activity,
+        top_target_app,
+        target_app_coverage,
     }
 }
 
@@ -170,6 +202,20 @@ mod tests {
             duration_secs: duration,
             word_count: words,
             provider: provider.into(),
+            target_app: None,
+        }
+    }
+
+    fn entry_with_app(ts_ms: u64, provider: &str, app: Option<&str>) -> HistoryEntry {
+        HistoryEntry {
+            id: format!("id-{ts_ms}"),
+            timestamp_ms: ts_ms,
+            text: String::new(),
+            enhanced: false,
+            duration_secs: 10.0,
+            word_count: 10,
+            provider: provider.into(),
+            target_app: app.map(str::to_owned),
         }
     }
 
@@ -192,6 +238,78 @@ mod tests {
         assert_eq!(s.longest_session_timestamp_ms, None);
         assert_eq!(s.activity_30d.len(), ACTIVITY_DAYS);
         assert!(s.providers.is_empty());
+        assert!(s.top_target_app.is_none());
+        assert_eq!(s.target_app_coverage, 0.0);
+    }
+
+    #[test]
+    fn aggregate_top_target_app_picks_most_frequent() {
+        let now = now_ms();
+        let hist = vec![
+            entry_with_app(now as u64, "groq", Some("Slack")),
+            entry_with_app(now as u64, "groq", Some("Chrome")),
+            entry_with_app(now as u64, "groq", Some("Slack")),
+            entry_with_app(now as u64, "groq", Some("Slack")),
+        ];
+        let s = aggregate(&hist, now);
+        let top = s.top_target_app.unwrap();
+        assert_eq!(top.name, "Slack");
+        assert_eq!(top.count, 3);
+        assert!((top.share - 0.75).abs() < 1e-9);
+    }
+
+    #[test]
+    fn aggregate_top_target_app_ignores_entries_without_target() {
+        let now = now_ms();
+        let hist = vec![
+            entry_with_app(now as u64, "groq", None),
+            entry_with_app(now as u64, "groq", None),
+            entry_with_app(now as u64, "groq", Some("Chrome")),
+        ];
+        let s = aggregate(&hist, now);
+        let top = s.top_target_app.unwrap();
+        assert_eq!(top.name, "Chrome");
+        assert_eq!(top.count, 1);
+        // share is relative to entries that have a target app, not total history
+        assert!((top.share - 1.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn aggregate_top_target_app_none_when_all_entries_lack_target() {
+        let now = now_ms();
+        let hist = vec![
+            entry_with_app(now as u64, "groq", None),
+            entry_with_app(now as u64, "groq", None),
+        ];
+        let s = aggregate(&hist, now);
+        assert!(s.top_target_app.is_none());
+        assert_eq!(s.target_app_coverage, 0.0);
+    }
+
+    #[test]
+    fn aggregate_target_app_coverage_fraction_of_history() {
+        let now = now_ms();
+        let hist = vec![
+            entry_with_app(now as u64, "groq", Some("Slack")),
+            entry_with_app(now as u64, "groq", None),
+            entry_with_app(now as u64, "groq", None),
+            entry_with_app(now as u64, "groq", Some("Chrome")),
+        ];
+        let s = aggregate(&hist, now);
+        assert!((s.target_app_coverage - 0.5).abs() < 1e-9);
+    }
+
+    #[test]
+    fn aggregate_target_app_ignores_whitespace_only_values() {
+        let now = now_ms();
+        let hist = vec![
+            entry_with_app(now as u64, "groq", Some("   ")),
+            entry_with_app(now as u64, "groq", Some("Slack")),
+        ];
+        let s = aggregate(&hist, now);
+        let top = s.top_target_app.unwrap();
+        assert_eq!(top.name, "Slack");
+        assert_eq!(top.count, 1);
     }
 
     #[test]

--- a/src-tauri/src/storage/mod.rs
+++ b/src-tauri/src/storage/mod.rs
@@ -43,6 +43,8 @@ pub struct HistoryEntry {
     pub duration_secs: f32,
     pub word_count: u32,
     pub provider: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub target_app: Option<String>,
 }
 
 // ── Path helpers ───────────────────────────────────────────────────────────────
@@ -112,7 +114,35 @@ pub(crate) fn load_from_path(path: &Path) -> Result<serde_json::Value, String> {
         return Ok(defaults());
     }
     let content = std::fs::read_to_string(path).map_err(|e| format!("STORAGE_ERROR: {e}"))?;
-    serde_json::from_str(&content).map_err(|e| format!("STORAGE_ERROR: {e}"))
+    let loaded: serde_json::Value =
+        serde_json::from_str(&content).map_err(|e| format!("STORAGE_ERROR: {e}"))?;
+    Ok(merge_defaults(loaded, defaults()))
+}
+
+/// Deep-merge `loaded` with `defaults`: any missing key in `loaded` is taken
+/// from `defaults`. Keeps the loaded values intact. Lets new settings sections
+/// appear for existing users without wiping their prior choices.
+fn merge_defaults(
+    mut loaded: serde_json::Value,
+    defaults: serde_json::Value,
+) -> serde_json::Value {
+    if let (serde_json::Value::Object(ref mut loaded_obj), serde_json::Value::Object(defaults_obj)) =
+        (&mut loaded, defaults)
+    {
+        for (k, default_v) in defaults_obj {
+            match loaded_obj.get_mut(&k) {
+                None => {
+                    loaded_obj.insert(k, default_v);
+                }
+                Some(existing) if existing.is_object() && default_v.is_object() => {
+                    let merged = merge_defaults(existing.take(), default_v);
+                    *existing = merged;
+                }
+                Some(_) => {}
+            }
+        }
+    }
+    loaded
 }
 
 pub(crate) fn save_to_path(path: &Path, value: &serde_json::Value) -> Result<(), String> {
@@ -187,6 +217,10 @@ pub(crate) fn defaults() -> serde_json::Value {
             "onboardingCompleted": false,
             "theme": "system",
             "audioInputDevice": null
+        },
+        "privacy": {
+            "historyTracking": true,
+            "targetAppTracking": false
         }
     })
 }
@@ -240,6 +274,46 @@ mod tests {
     #[test]
     fn defaults_ai_enhancement_disabled() {
         assert_eq!(defaults()["aiEnhancement"]["enabled"], false);
+    }
+
+    #[test]
+    fn defaults_privacy_history_on_target_app_off() {
+        let d = defaults();
+        assert_eq!(d["privacy"]["historyTracking"], true);
+        assert_eq!(d["privacy"]["targetAppTracking"], false);
+    }
+
+    // ── merge_defaults ────────────────────────────────────────────────────────
+
+    #[test]
+    fn merge_fills_missing_top_level_section() {
+        let loaded = serde_json::json!({
+            "general": { "language": "en", "autostart": false, "onboardingCompleted": false, "theme": "system", "audioInputDevice": null }
+        });
+        let merged = merge_defaults(loaded, defaults());
+        assert_eq!(merged["privacy"]["historyTracking"], true);
+        assert_eq!(merged["general"]["language"], "en");
+    }
+
+    #[test]
+    fn merge_preserves_loaded_values_over_defaults() {
+        let loaded = serde_json::json!({
+            "general": { "language": "en" }
+        });
+        let merged = merge_defaults(loaded, defaults());
+        assert_eq!(merged["general"]["language"], "en");
+        // Missing sibling keys are filled in from defaults
+        assert_eq!(merged["general"]["theme"], "system");
+    }
+
+    #[test]
+    fn merge_fills_missing_nested_keys() {
+        let loaded = serde_json::json!({
+            "privacy": { "historyTracking": false }
+        });
+        let merged = merge_defaults(loaded, defaults());
+        assert_eq!(merged["privacy"]["historyTracking"], false);
+        assert_eq!(merged["privacy"]["targetAppTracking"], false);
     }
 
     // ── load_from_path ────────────────────────────────────────────────────────

--- a/src-tauri/src/target_app/labels.rs
+++ b/src-tauri/src/target_app/labels.rs
@@ -1,0 +1,151 @@
+// Maps raw process names (Windows) and bundle identifiers (macOS) to
+// human-readable labels. Lookup is case-insensitive, `.exe` is stripped.
+// Unknown inputs pass through with `.exe` stripped so the UI still shows
+// something sensible.
+
+const KNOWN_APPS: &[(&str, &str)] = &[
+    // Chat / messaging
+    ("slack", "Slack"),
+    ("com.tinyspeck.slackmacgap", "Slack"),
+    ("discord", "Discord"),
+    ("com.hnc.discord", "Discord"),
+    ("telegram", "Telegram"),
+    ("ru.keepcoder.telegram", "Telegram"),
+    ("whatsapp", "WhatsApp"),
+    ("net.whatsapp.whatsapp", "WhatsApp"),
+    ("teams", "Teams"),
+    ("ms-teams", "Teams"),
+    ("com.microsoft.teams", "Teams"),
+    ("com.microsoft.teams2", "Teams"),
+    ("messages", "Messages"),
+    ("com.apple.mobilesms", "Messages"),
+    // Browsers
+    ("chrome", "Chrome"),
+    ("google chrome", "Chrome"),
+    ("com.google.chrome", "Chrome"),
+    ("firefox", "Firefox"),
+    ("org.mozilla.firefox", "Firefox"),
+    ("msedge", "Edge"),
+    ("com.microsoft.edge", "Edge"),
+    ("brave", "Brave"),
+    ("com.brave.browser", "Brave"),
+    ("arc", "Arc"),
+    ("company.thebrowser.browser", "Arc"),
+    ("safari", "Safari"),
+    ("com.apple.safari", "Safari"),
+    // Editors
+    ("code", "VS Code"),
+    ("visual studio code", "VS Code"),
+    ("com.microsoft.vscode", "VS Code"),
+    ("cursor", "Cursor"),
+    ("com.todesktop.230313mzl4w4u92", "Cursor"),
+    // Notes
+    ("notion", "Notion"),
+    ("notion.id", "Notion"),
+    ("obsidian", "Obsidian"),
+    ("md.obsidian", "Obsidian"),
+    // Mail / calendar
+    ("outlook", "Outlook"),
+    ("com.microsoft.outlook", "Outlook"),
+    ("mail", "Mail"),
+    ("com.apple.mail", "Mail"),
+    // System / productivity
+    ("explorer", "Explorer"),
+    ("finder", "Finder"),
+    ("com.apple.finder", "Finder"),
+    ("terminal", "Terminal"),
+    ("com.apple.terminal", "Terminal"),
+    ("iterm2", "iTerm"),
+    ("com.googlecode.iterm2", "iTerm"),
+    // Meetings
+    ("zoom", "Zoom"),
+    ("us.zoom.xos", "Zoom"),
+];
+
+pub fn pretty_label(raw: &str) -> String {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return String::new();
+    }
+
+    let lowered = trimmed.to_lowercase();
+    let lookup_key = lowered.strip_suffix(".exe").unwrap_or(&lowered);
+
+    for (needle, label) in KNOWN_APPS {
+        if lookup_key == *needle {
+            return (*label).to_string();
+        }
+    }
+
+    // Fallback: keep the raw casing but strip the .exe suffix so users don't
+    // see "MyApp.exe" in their stats.
+    let suffix_len = trimmed.len().saturating_sub(lookup_key.len());
+    if suffix_len > 0 && lookup_key.len() < trimmed.len() {
+        trimmed[..trimmed.len() - suffix_len].to_string()
+    } else {
+        trimmed.to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn pretty_label_strips_exe_and_matches_known_app() {
+        assert_eq!(pretty_label("chrome.exe"), "Chrome");
+        assert_eq!(pretty_label("Firefox.exe"), "Firefox");
+        assert_eq!(pretty_label("Slack.exe"), "Slack");
+    }
+
+    #[test]
+    fn pretty_label_case_insensitive_exe_suffix() {
+        assert_eq!(pretty_label("Slack.EXE"), "Slack");
+    }
+
+    #[test]
+    fn pretty_label_matches_macos_bundle_ids() {
+        assert_eq!(pretty_label("com.tinyspeck.slackmacgap"), "Slack");
+        assert_eq!(pretty_label("md.obsidian"), "Obsidian");
+        assert_eq!(pretty_label("com.apple.safari"), "Safari");
+    }
+
+    #[test]
+    fn pretty_label_bundle_id_case_insensitive() {
+        assert_eq!(pretty_label("com.Apple.Safari"), "Safari");
+    }
+
+    #[test]
+    fn pretty_label_falls_back_to_raw_without_exe_when_unknown() {
+        assert_eq!(pretty_label("MyCustomApp.exe"), "MyCustomApp");
+    }
+
+    #[test]
+    fn pretty_label_unknown_bundle_id_passes_through_verbatim() {
+        assert_eq!(pretty_label("com.example.weirdapp"), "com.example.weirdapp");
+    }
+
+    #[test]
+    fn pretty_label_empty_input_returns_empty() {
+        assert_eq!(pretty_label(""), "");
+        assert_eq!(pretty_label("   "), "");
+    }
+
+    #[test]
+    fn pretty_label_trims_whitespace() {
+        assert_eq!(pretty_label("  chrome.exe  "), "Chrome");
+    }
+
+    #[test]
+    fn pretty_label_vscode_variants() {
+        assert_eq!(pretty_label("Code.exe"), "VS Code");
+        assert_eq!(pretty_label("com.microsoft.VSCode"), "VS Code");
+    }
+
+    #[test]
+    fn pretty_label_teams_variants() {
+        assert_eq!(pretty_label("Teams.exe"), "Teams");
+        assert_eq!(pretty_label("ms-teams.exe"), "Teams");
+        assert_eq!(pretty_label("com.microsoft.teams2"), "Teams");
+    }
+}

--- a/src-tauri/src/target_app/mod.rs
+++ b/src-tauri/src/target_app/mod.rs
@@ -1,0 +1,76 @@
+pub mod labels;
+
+/// Returns the frontmost application's raw identifier:
+/// - Windows: executable file name (e.g. "Slack.exe")
+/// - macOS:   bundle identifier   (e.g. "com.tinyspeck.slackmacgap")
+/// - Other:   `None`
+///
+/// The caller decides whether to call this — gate on the user's privacy
+/// setting before invoking.
+pub fn capture() -> Option<String> {
+    #[cfg(target_os = "windows")]
+    {
+        return capture_windows();
+    }
+    #[cfg(target_os = "macos")]
+    {
+        return capture_macos();
+    }
+    #[cfg(not(any(target_os = "windows", target_os = "macos")))]
+    {
+        None
+    }
+}
+
+#[cfg(target_os = "windows")]
+fn capture_windows() -> Option<String> {
+    use windows::core::PWSTR;
+    use windows::Win32::Foundation::CloseHandle;
+    use windows::Win32::System::Threading::{
+        OpenProcess, QueryFullProcessImageNameW, PROCESS_NAME_WIN32,
+        PROCESS_QUERY_LIMITED_INFORMATION,
+    };
+    use windows::Win32::UI::WindowsAndMessaging::{GetForegroundWindow, GetWindowThreadProcessId};
+
+    unsafe {
+        let hwnd = GetForegroundWindow();
+        if hwnd.0.is_null() {
+            return None;
+        }
+        let mut pid: u32 = 0;
+        GetWindowThreadProcessId(hwnd, Some(&mut pid));
+        if pid == 0 {
+            return None;
+        }
+
+        let handle = OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, false, pid).ok()?;
+
+        let mut buf = [0u16; 512];
+        let mut size: u32 = buf.len() as u32;
+        let result = QueryFullProcessImageNameW(
+            handle,
+            PROCESS_NAME_WIN32,
+            PWSTR(buf.as_mut_ptr()),
+            &mut size,
+        );
+        let _ = CloseHandle(handle);
+
+        if result.is_err() || size == 0 {
+            return None;
+        }
+
+        let path = String::from_utf16_lossy(&buf[..size as usize]);
+        path.rsplit(['\\', '/']).next().map(str::to_owned)
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn capture_macos() -> Option<String> {
+    use objc2_app_kit::NSWorkspace;
+
+    unsafe {
+        let workspace = NSWorkspace::sharedWorkspace();
+        let app = workspace.frontmostApplication()?;
+        app.bundleIdentifier().map(|s| s.to_string())
+    }
+}

--- a/src-tauri/src/transcription/mod.rs
+++ b/src-tauri/src/transcription/mod.rs
@@ -101,6 +101,21 @@ pub async fn process(app: AppHandle) {
 
     let paste_text = format!("{} ", final_text.trim());
 
+    let history_tracking = settings["privacy"]["historyTracking"]
+        .as_bool()
+        .unwrap_or(true);
+    let target_app_tracking = settings["privacy"]["targetAppTracking"]
+        .as_bool()
+        .unwrap_or(false);
+
+    // Capture must happen while the user's target app is still frontmost —
+    // i.e. before we simulate Ctrl+V. Skip entirely when either toggle is off.
+    let target_app = if history_tracking && target_app_tracking {
+        crate::target_app::capture()
+    } else {
+        None
+    };
+
     transition_to_inserting(&app);
     if let Err(e) = crate::clipboard::paste(&paste_text) {
         crate::errors::emit(&app, "PASTE_FAILED", &e);
@@ -109,19 +124,22 @@ pub async fn process(app: AppHandle) {
     }
     transition_to_idle(&app);
 
-    let timestamp_ms = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .map(|d| d.as_millis() as u64)
-        .unwrap_or(0);
-    let _ = crate::storage::append_history_entry(&app, crate::storage::HistoryEntry {
-        id: timestamp_ms.to_string(),
-        timestamp_ms,
-        text: final_text.trim().to_owned(),
-        enhanced: was_enhanced,
-        duration_secs,
-        word_count,
-        provider,
-    });
+    if history_tracking {
+        let timestamp_ms = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_millis() as u64)
+            .unwrap_or(0);
+        let _ = crate::storage::append_history_entry(&app, crate::storage::HistoryEntry {
+            id: timestamp_ms.to_string(),
+            timestamp_ms,
+            text: final_text.trim().to_owned(),
+            enhanced: was_enhanced,
+            duration_secs,
+            word_count,
+            provider,
+            target_app,
+        });
+    }
 
     let _ = app.emit("transcription-result", TranscriptionResultPayload { text: final_text.trim().to_owned() });
 }

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -66,6 +66,13 @@
       "inputDevice": "Eingabegerät",
       "inputDeviceDefault": "Standard (Systemvorgabe)"
     },
+    "privacy": {
+      "section": "Datenschutz",
+      "historyTracking": "Verlauf speichern",
+      "historyTrackingDesc": "Transkripte werden lokal gespeichert und in History und Stats angezeigt.",
+      "targetAppTracking": "Ziel-App erfassen",
+      "targetAppTrackingDesc": "Merkt sich, in welche App du einfügst – nur für die \"Häufigstes Ziel\"-Statistik. Bleibt lokal."
+    },
     "transcription": {
       "method": "Methode",
       "mode": {

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -66,6 +66,13 @@
       "inputDevice": "Input device",
       "inputDeviceDefault": "Default (system)"
     },
+    "privacy": {
+      "section": "Privacy",
+      "historyTracking": "Keep transcript history",
+      "historyTrackingDesc": "Transcripts are stored locally and shown in History and Stats.",
+      "targetAppTracking": "Record target app",
+      "targetAppTrackingDesc": "Remembers which app you paste into — used only for the \"Most common target\" stat. Stays local."
+    },
     "transcription": {
       "method": "Method",
       "mode": {

--- a/src/pages/StatsPage.tsx
+++ b/src/pages/StatsPage.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react'
 import { invoke } from '@tauri-apps/api/core'
 
 type ProviderStat = { name: string; count: number; share: number }
+type TargetAppStat = { name: string; count: number; share: number }
 
 type StatsSummary = {
   totalWords: number
@@ -17,6 +18,8 @@ type StatsSummary = {
   aiPolishRate: number
   providers: ProviderStat[]
   activity30d: number[]
+  topTargetApp: TargetAppStat | null
+  targetAppCoverage: number
 }
 
 const EMPTY: StatsSummary = {
@@ -33,6 +36,8 @@ const EMPTY: StatsSummary = {
   aiPolishRate: 0,
   providers: [],
   activity30d: Array(30).fill(0),
+  topTargetApp: null,
+  targetAppCoverage: 0,
 }
 
 const PROVIDER_LABELS: Record<string, string> = {
@@ -117,6 +122,11 @@ export function StatsPage() {
           <div className="desc">{formatLongestDate(stats.longestSessionTimestampMs)}</div>
         </div>
         <div className="cell">
+          <div className="k">Häufigstes Ziel</div>
+          <div className="v">{stats.topTargetApp ? stats.topTargetApp.name : '—'}</div>
+          <div className="desc">{formatTargetAppDesc(stats.topTargetApp, stats.targetAppCoverage)}</div>
+        </div>
+        <div className="cell">
           <div className="k">AI-Polish Quote</div>
           <div className="v">{Math.round(stats.aiPolishRate * 100)}%</div>
           <div className="desc">Anteil mit Enhancement</div>
@@ -169,6 +179,15 @@ function formatLongestDate(ms: number | null): string {
   if (!ms) return 'Noch keine Sessions'
   const d = new Date(ms)
   return new Intl.DateTimeFormat('de-DE', { day: 'numeric', month: 'long' }).format(d)
+}
+
+function formatTargetAppDesc(top: TargetAppStat | null, coverage: number): string {
+  if (!top) {
+    return coverage === 0
+      ? 'Tracking deaktiviert oder noch keine Daten'
+      : 'Noch keine Daten'
+  }
+  return `${Math.round(top.share * 100)}% aller erfassten Ziele`
 }
 
 function formatWeekTrend(thisWeek: number, lastWeek: number): string {

--- a/src/pages/settings/GeneralSettings.tsx
+++ b/src/pages/settings/GeneralSettings.tsx
@@ -60,6 +60,20 @@ export function GeneralSettings({ settings, onChange }: Props) {
     onChange({ ...settings, general: { ...settings.general, onboardingCompleted: false } })
   }
 
+  const historyTracking = settings.privacy?.historyTracking ?? true
+  const targetAppTracking = settings.privacy?.targetAppTracking ?? false
+
+  function togglePrivacy(key: 'historyTracking' | 'targetAppTracking') {
+    const current = { historyTracking, targetAppTracking }
+    const next = { ...current, [key]: !current[key] }
+    // Turning the master off implicitly disables the sub-toggle so we never
+    // persist a contradictory "history off, target-app on" state.
+    if (key === 'historyTracking' && !next.historyTracking) {
+      next.targetAppTracking = false
+    }
+    onChange({ ...settings, privacy: next })
+  }
+
   return (
     <div>
       <p className="page-eyebrow">einstellungen</p>
@@ -129,6 +143,35 @@ export function GeneralSettings({ settings, onChange }: Props) {
         >
           {t('settings.general.onboarding')}
         </button>
+      </SettingRow>
+
+      <p className="sec-head">{t('settings.privacy.section')}</p>
+
+      <SettingRow
+        label={t('settings.privacy.historyTracking')}
+        description={t('settings.privacy.historyTrackingDesc')}
+      >
+        <button
+          role="switch"
+          aria-checked={historyTracking}
+          onClick={() => togglePrivacy('historyTracking')}
+          className={`v-switch${historyTracking ? ' on' : ''}`}
+        />
+      </SettingRow>
+
+      <SettingRow
+        label={t('settings.privacy.targetAppTracking')}
+        description={t('settings.privacy.targetAppTrackingDesc')}
+      >
+        <button
+          role="switch"
+          aria-checked={targetAppTracking && historyTracking}
+          aria-disabled={!historyTracking}
+          disabled={!historyTracking}
+          onClick={() => togglePrivacy('targetAppTracking')}
+          className={`v-switch${targetAppTracking && historyTracking ? ' on' : ''}`}
+          style={{ opacity: historyTracking ? 1 : 0.4, cursor: historyTracking ? 'pointer' : 'not-allowed' }}
+        />
       </SettingRow>
     </div>
   )

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -47,6 +47,10 @@ export interface Settings {
     theme: 'light' | 'dark' | 'system'
     audioInputDevice: string | null
   }
+  privacy: {
+    historyTracking: boolean
+    targetAppTracking: boolean
+  }
 }
 
 export type AppState = 'idle' | 'recording' | 'processing' | 'inserting' | 'error'


### PR DESCRIPTION
Adds a Datenschutz section in General Settings with two toggles:
- Verlauf speichern (master, default ON) — gates HistoryEntry writes
- Ziel-App erfassen (sub, default OFF) — captures frontmost app on insert

When Verlauf is OFF, no HistoryEntry is written and Stats/History pages show empty state. When Ziel-App is ON, transcription captures the frontmost app just before the paste keystroke and stores the raw name on HistoryEntry. The UI layer maps known process names and bundle IDs to pretty labels and falls back to the raw string for unknowns.

Platforms:
- Windows: GetForegroundWindow + QueryFullProcessImageNameW
- macOS:   NSWorkspace.frontmostApplication (bundle identifier)
- Linux:   stub, returns None

Stats gains top_target_app and target_app_coverage; StatsPage renders the 'Häufigstes Ziel' card again, now backed by real data.

Also adds merge_defaults on settings load so existing users whose settings.json predates the new privacy section get it filled in without wiping their prior choices.

Closes #21