### PR TITLE
feat: split transcription language from UI language

### DIFF
--- a/src-tauri/src/local_transcription/mod.rs
+++ b/src-tauri/src/local_transcription/mod.rs
@@ -16,7 +16,14 @@ pub fn transcribe_with_context(ctx: &WhisperContext, wav_bytes: &[u8], language:
 
     let mut params = FullParams::new(SamplingStrategy::Greedy { best_of: 0 });
     params.set_n_threads(n_threads);
-    params.set_language(Some(language));
+    // Empty/"auto" means auto-detect: pass None so whisper.cpp does the detection
+    // itself instead of being forced onto whatever UI-language string leaks in.
+    let lang_hint = if language.is_empty() || language.eq_ignore_ascii_case("auto") {
+        None
+    } else {
+        Some(language)
+    };
+    params.set_language(lang_hint);
     params.set_translate(false);
     params.set_print_special(false);
     params.set_print_progress(false);

--- a/src-tauri/src/storage/mod.rs
+++ b/src-tauri/src/storage/mod.rs
@@ -227,7 +227,8 @@ pub(crate) fn defaults() -> serde_json::Value {
             "localModelSize": "base",
             "cloudProvider": "groq",
             "cloudModel": "",
-            "cloudCustomEndpoint": ""
+            "cloudCustomEndpoint": "",
+            "language": "auto"
         },
         "aiEnhancement": {
             "enabled": false,
@@ -294,6 +295,34 @@ mod tests {
     #[test]
     fn defaults_transcription_mode_is_cloud() {
         assert_eq!(defaults()["transcription"]["mode"], "cloud");
+    }
+
+    #[test]
+    fn defaults_transcription_language_is_auto() {
+        assert_eq!(defaults()["transcription"]["language"], "auto");
+    }
+
+    #[test]
+    fn merge_fills_missing_transcription_language_with_auto() {
+        // Simulates an existing install upgrading to the version that
+        // introduces `transcription.language`: the key is absent and must
+        // be backfilled to "auto", not copied from general.language.
+        let loaded = serde_json::json!({
+            "general": { "language": "de" },
+            "transcription": { "mode": "cloud", "cloudProvider": "groq" }
+        });
+        let merged = merge_defaults(loaded, defaults());
+        assert_eq!(merged["transcription"]["language"], "auto");
+        assert_eq!(merged["general"]["language"], "de");
+    }
+
+    #[test]
+    fn merge_preserves_explicit_transcription_language() {
+        let loaded = serde_json::json!({
+            "transcription": { "language": "en" }
+        });
+        let merged = merge_defaults(loaded, defaults());
+        assert_eq!(merged["transcription"]["language"], "en");
     }
 
     #[test]

--- a/src-tauri/src/transcription/mod.rs
+++ b/src-tauri/src/transcription/mod.rs
@@ -26,9 +26,12 @@ pub async fn process(app: AppHandle) {
 
     let settings = crate::storage::load(&app).unwrap_or_default();
 
-    let language = settings["general"]["language"]
+    // Transcription language is an independent setting from UI language.
+    // "auto" (the default) lets the STT provider detect the language itself,
+    // which avoids forcing a wrong hint when the speaker mixes languages.
+    let language = settings["transcription"]["language"]
         .as_str()
-        .unwrap_or("de")
+        .unwrap_or("auto")
         .to_owned();
 
     let mode = settings["transcription"]["mode"]
@@ -284,8 +287,10 @@ async fn call_openai_compat(
 
     let mut form = reqwest::multipart::Form::new()
         .part("file", part)
-        .text("model", model.to_owned())
-        .text("language", language.to_owned());
+        .text("model", model.to_owned());
+    if !is_auto_language(language) {
+        form = form.text("language", language.to_owned());
+    }
     if let Some(prompt) = initial_prompt {
         form = form.text("prompt", prompt.to_owned());
     }
@@ -339,10 +344,15 @@ async fn call_deepgram(
                 .collect::<String>()
         })
         .unwrap_or_default();
+    let language_param = if is_auto_language(language) {
+        "detect_language=true".to_owned()
+    } else {
+        format!("language={language}")
+    };
     let client = reqwest::Client::new();
     let response = client
         .post(format!(
-            "https://api.deepgram.com/v1/listen?language={language}&model={model}&smart_format=true{keywords}"
+            "https://api.deepgram.com/v1/listen?{language_param}&model={model}&smart_format=true{keywords}"
         ))
         .header("Authorization", format!("Token {api_key}"))
         .header("Content-Type", "audio/wav")
@@ -392,7 +402,7 @@ async fn call_elevenlabs(
         .part("file", part)
         .text("model_id", model.to_owned());
 
-    if !language.is_empty() {
+    if !is_auto_language(language) {
         form = form.text("language_code", language.to_owned());
     }
 
@@ -446,7 +456,7 @@ async fn call_gemini(
         .map(|p| format!(" Pay attention to these terms: {p}."))
         .unwrap_or_default();
 
-    let prompt = if language.is_empty() || language == "auto" {
+    let prompt = if is_auto_language(language) {
         format!("Transcribe the following audio. Return only the transcribed text, nothing else.{vocab_hint}")
     } else {
         format!("Transcribe the following audio in {language}. Return only the transcribed text, nothing else.{vocab_hint}")
@@ -575,6 +585,10 @@ async fn maybe_enhance(
 }
 
 // ── Helpers ────────────────────────────────────────────────────────────────────
+
+pub(crate) fn is_auto_language(language: &str) -> bool {
+    language.is_empty() || language.eq_ignore_ascii_case("auto")
+}
 
 fn build_dict_prompt(app: &AppHandle) -> Option<String> {
     let entries = crate::storage::load_dictionary(app).ok()?;
@@ -744,6 +758,27 @@ mod tests {
 
     fn make_entry(word: &str) -> DictionaryEntry {
         DictionaryEntry { id: "test".into(), word: word.into() }
+    }
+
+    // ── is_auto_language ──────────────────────────────────────────────────────
+
+    #[test]
+    fn is_auto_language_matches_empty_string() {
+        assert!(is_auto_language(""));
+    }
+
+    #[test]
+    fn is_auto_language_matches_auto_case_insensitively() {
+        assert!(is_auto_language("auto"));
+        assert!(is_auto_language("Auto"));
+        assert!(is_auto_language("AUTO"));
+    }
+
+    #[test]
+    fn is_auto_language_rejects_explicit_codes() {
+        assert!(!is_auto_language("de"));
+        assert!(!is_auto_language("en"));
+        assert!(!is_auto_language("es"));
     }
 
     // ── apply_snippets_to_text ────────────────────────────────────────────────

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -57,6 +57,8 @@
     },
     "general": {
       "language": "Sprache",
+      "uiLanguage": "Oberflächensprache",
+      "uiLanguageDescription": "Sprache der VOCA-Benutzeroberfläche. Hat keinen Einfluss auf die Transkription.",
       "theme": "Design",
       "themeDark": "Dunkel",
       "themeLight": "Hell",
@@ -78,6 +80,17 @@
       "mode": {
         "cloud": "Cloud",
         "local": "Lokal"
+      },
+      "language": "Sprache der Aufnahme",
+      "languageDescription": "Sprach-Hinweis für die Transkription. \"Automatisch\" lässt den Anbieter die Sprache selbst erkennen.",
+      "languageOption": {
+        "auto": "Automatisch",
+        "de": "Deutsch",
+        "en": "English",
+        "es": "Español",
+        "fr": "Français",
+        "pt": "Português",
+        "it": "Italiano"
       },
       "apiKey": "API Key",
       "localModel": "Lokales Modell",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -57,6 +57,8 @@
     },
     "general": {
       "language": "Language",
+      "uiLanguage": "Interface language",
+      "uiLanguageDescription": "Language of the VOCA user interface. Does not affect transcription.",
       "theme": "Theme",
       "themeDark": "Dark",
       "themeLight": "Light",
@@ -78,6 +80,17 @@
       "mode": {
         "cloud": "Cloud",
         "local": "Local"
+      },
+      "language": "Spoken language",
+      "languageDescription": "Language hint for transcription. \"Auto\" lets the provider detect the language itself.",
+      "languageOption": {
+        "auto": "Auto",
+        "de": "Deutsch",
+        "en": "English",
+        "es": "Español",
+        "fr": "Français",
+        "pt": "Português",
+        "it": "Italiano"
       },
       "apiKey": "API Key",
       "localModel": "Local model",

--- a/src/pages/settings/GeneralSettings.tsx
+++ b/src/pages/settings/GeneralSettings.tsx
@@ -79,7 +79,10 @@ export function GeneralSettings({ settings, onChange }: Props) {
       <p className="page-eyebrow">einstellungen</p>
       <h1 className="page-title" style={{ marginBottom: 28 }}>{t('settings.nav.general')}</h1>
 
-      <SettingRow label={t('settings.general.language')}>
+      <SettingRow
+        label={t('settings.general.uiLanguage')}
+        description={t('settings.general.uiLanguageDescription')}
+      >
         <div className="v-seg">
           {(['de', 'en'] as const).map((lang) => (
             <button

--- a/src/pages/settings/TranscriptionSettings.tsx
+++ b/src/pages/settings/TranscriptionSettings.tsx
@@ -4,7 +4,8 @@ import { invoke } from '@tauri-apps/api/core'
 import { listen } from '@tauri-apps/api/event'
 import { open } from '@tauri-apps/plugin-shell'
 import { SettingRow } from '../../components/settings/SettingRow'
-import type { Settings } from '../../types'
+import { TRANSCRIPTION_LANGUAGES } from '../../types'
+import type { Settings, TranscriptionLanguage } from '../../types'
 
 interface Props {
   settings: Settings
@@ -168,6 +169,10 @@ export function TranscriptionSettings({ settings, onChange }: Props) {
     onChange({ ...settings, transcription: { ...settings.transcription, mode } })
   }
 
+  function handleLanguageChange(language: TranscriptionLanguage) {
+    onChange({ ...settings, transcription: { ...settings.transcription, language } })
+  }
+
   function handleModelSizeChange(size: ModelSize) {
     onChange({ ...settings, transcription: { ...settings.transcription, localModelSize: size } })
   }
@@ -226,6 +231,23 @@ export function TranscriptionSettings({ settings, onChange }: Props) {
             </button>
           ))}
         </div>
+      </SettingRow>
+
+      <SettingRow
+        label={t('settings.transcription.language')}
+        description={t('settings.transcription.languageDescription')}
+      >
+        <select
+          value={settings.transcription.language ?? 'auto'}
+          onChange={(e) => handleLanguageChange(e.target.value as TranscriptionLanguage)}
+          className="w-48 px-2.5 py-1.5 text-xs bg-surface border border-border rounded-lg text-text focus:outline-none focus:border-accent"
+        >
+          {TRANSCRIPTION_LANGUAGES.map((lang) => (
+            <option key={lang} value={lang}>
+              {t(`settings.transcription.languageOption.${lang}`)}
+            </option>
+          ))}
+        </select>
       </SettingRow>
 
       {!isLocal && (

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -27,6 +27,7 @@ export interface Settings {
     cloudProvider: 'openai' | 'groq' | 'deepgram' | 'elevenlabs' | 'gemini' | 'custom'
     cloudModel: string
     cloudCustomEndpoint: string
+    language: TranscriptionLanguage
   }
   aiEnhancement: {
     enabled: boolean
@@ -52,6 +53,18 @@ export interface Settings {
     targetAppTracking: boolean
   }
 }
+
+export type TranscriptionLanguage = 'auto' | 'de' | 'en' | 'es' | 'fr' | 'pt' | 'it'
+
+export const TRANSCRIPTION_LANGUAGES: TranscriptionLanguage[] = [
+  'auto',
+  'de',
+  'en',
+  'es',
+  'fr',
+  'pt',
+  'it',
+]
 
 export type AppState = 'idle' | 'recording' | 'processing' | 'inserting' | 'error'
 


### PR DESCRIPTION
  Introduces `transcription.language` as an independent setting so the STT language hint is no longer forced from the UI locale — fixes the Denglisch mis-transcription where German UI caused "For-Schleife" to 
  be rendered as "Fürschleife".                                                                                                                                                                                  
  
  ## Changes                                                                                                                                                                                                     
                                                                                                                                                                                                               
  - New `transcription.language` key in storage defaults, default `"auto"`. Existing installs get the key backfilled to `"auto"` on load (migration test added); the old `general.language` value is             
  intentionally not copied over.
  - STT pipeline now reads from `settings["transcription"]["language"]`. Every provider adapter handles `"auto"` (or empty) by omitting the language hint:                                                       
    - OpenAI-compatible (OpenAI, Groq, custom): drops the `language` form field                                                                                                                                  
    - Deepgram: swaps to `detect_language=true`                                                                                                                                                                  
    - ElevenLabs: drops `language_code`                                                                                                                                                                          
    - Gemini: unified through the new helper (existing auto-handling preserved)                                                                                                                                  
    - Local whisper-rs: passes `None` to `set_language` so whisper.cpp detects                                                                                                                                   
  - New `is_auto_language()` helper with unit tests covering empty, "auto", case variants, and explicit codes.                                                                                                   
  - Transcription settings page gets a new "Spoken language" dropdown: Auto (default), Deutsch, English, Español, Français, Português, Italiano. Option list is pre-seeded with the six UI locales #26 will bring
   in, so no duplicate work later.                                                                                                                                                                               
  - General settings language row keeps controlling the UI locale; copy is updated to "UI language" / "Oberflächensprache" with a description making the distinction explicit.                                   
                                                                                                                                                                                                                 
  ## Test plan                                                                                                                                                                                                 
                                                                                                                                                                                                                 
  - [ ] Fresh install → `transcription.language` defaults to `auto`, STT hit auto-detects German dictation correctly                                                                                             
  - [ ] Existing install with `general.language: "de"` → after upgrade, `transcription.language` shows `auto` (not `de`)
  - [ ] Switch transcription language to `English` → subsequent dictation uses EN hint on the chosen provider                                                                                                    
  - [ ] Switch UI language in General settings → only the UI flips, transcription setting unchanged                                                                                                              
  - [ ] Try on at least Groq (multipart) and one URL-based provider path                                                                                                                                         
                                                                                                                                                                                                                 
  Closes #24                                                                                                                                                                                                     
  Closes #25                                                                                                                                                                                                     
  Closes #27