### PR TITLE
feat: filler-word removal with manual list and master toggle

### DIFF
--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -248,6 +248,16 @@ pub fn save_snippets(app: tauri::AppHandle, snippets: Vec<crate::storage::Snippe
 }
 
 #[tauri::command]
+pub fn get_fillers(app: tauri::AppHandle) -> Result<Vec<crate::storage::FillerEntry>, String> {
+    crate::storage::load_fillers(&app)
+}
+
+#[tauri::command]
+pub fn save_fillers(app: tauri::AppHandle, entries: Vec<crate::storage::FillerEntry>) -> Result<(), String> {
+    crate::storage::save_fillers(&app, &entries)
+}
+
+#[tauri::command]
 pub fn get_autostart(app: tauri::AppHandle) -> Result<bool, String> {
     app.autolaunch().is_enabled().map_err(|e| e.to_string())
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -180,6 +180,8 @@ pub fn run() {
             commands::save_dictionary,
             commands::get_snippets,
             commands::save_snippets,
+            commands::get_fillers,
+            commands::save_fillers,
             commands::get_autostart,
             commands::set_autostart,
             commands::get_history,

--- a/src-tauri/src/storage/mod.rs
+++ b/src-tauri/src/storage/mod.rs
@@ -65,6 +65,13 @@ pub struct DictionaryEntry {
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
+pub struct FillerEntry {
+    pub id: String,
+    pub word: String,
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct HistoryEntry {
     pub id: String,
     pub timestamp_ms: u64,
@@ -90,6 +97,9 @@ fn snippets_path(app: &AppHandle) -> Result<PathBuf, String> {
 }
 fn dictionary_path(app: &AppHandle) -> Result<PathBuf, String> {
     app.path().app_data_dir().map(|p| p.join("dictionary.json")).map_err(|e| format!("STORAGE_ERROR: {e}"))
+}
+fn fillers_path(app: &AppHandle) -> Result<PathBuf, String> {
+    app.path().app_data_dir().map(|p| p.join("fillers.json")).map_err(|e| format!("STORAGE_ERROR: {e}"))
 }
 fn history_path(app: &AppHandle) -> Result<PathBuf, String> {
     app.path().app_data_dir().map(|p| p.join("history.json")).map_err(|e| format!("STORAGE_ERROR: {e}"))
@@ -120,6 +130,12 @@ pub fn load_dictionary(app: &AppHandle) -> Result<Vec<DictionaryEntry>, String> 
 }
 pub fn save_dictionary(app: &AppHandle, entries: &[DictionaryEntry]) -> Result<(), String> {
     save_to_path_raw(&dictionary_path(app)?, entries)
+}
+pub fn load_fillers(app: &AppHandle) -> Result<Vec<FillerEntry>, String> {
+    load_vec_from_path(&fillers_path(app)?)
+}
+pub fn save_fillers(app: &AppHandle, entries: &[FillerEntry]) -> Result<(), String> {
+    save_to_path_raw(&fillers_path(app)?, entries)
 }
 pub fn load_history(app: &AppHandle) -> Result<Vec<HistoryEntry>, String> {
     load_vec_from_path(&history_path(app)?)
@@ -228,7 +244,8 @@ pub(crate) fn defaults() -> serde_json::Value {
             "cloudProvider": "groq",
             "cloudModel": "",
             "cloudCustomEndpoint": "",
-            "language": "auto"
+            "language": "auto",
+            "removeFillerWords": false
         },
         "aiEnhancement": {
             "enabled": false,
@@ -300,6 +317,22 @@ mod tests {
     #[test]
     fn defaults_transcription_language_is_auto() {
         assert_eq!(defaults()["transcription"]["language"], "auto");
+    }
+
+    #[test]
+    fn defaults_filler_removal_is_off() {
+        // Opt-in only — deletion is destructive, same principle as
+        // privacy.targetAppTracking.
+        assert_eq!(defaults()["transcription"]["removeFillerWords"], false);
+    }
+
+    #[test]
+    fn merge_fills_missing_filler_removal_flag_with_false() {
+        let loaded = serde_json::json!({
+            "transcription": { "mode": "cloud" }
+        });
+        let merged = merge_defaults(loaded, defaults());
+        assert_eq!(merged["transcription"]["removeFillerWords"], false);
     }
 
     #[test]

--- a/src-tauri/src/transcription/mod.rs
+++ b/src-tauri/src/transcription/mod.rs
@@ -87,7 +87,8 @@ pub async fn process(app: AppHandle) {
         }
     };
 
-    let expanded_text = apply_snippets(&app, raw_text);
+    let filtered_text = maybe_remove_fillers(&app, &settings, raw_text);
+    let expanded_text = apply_snippets(&app, filtered_text);
     let pre_enhance = expanded_text.clone();
     let final_text = maybe_enhance(&app, &settings, expanded_text).await;
 
@@ -610,6 +611,69 @@ fn apply_snippets(app: &AppHandle, text: String) -> String {
     apply_snippets_to_text(text, &snippets)
 }
 
+fn maybe_remove_fillers(
+    app: &AppHandle,
+    settings: &serde_json::Value,
+    text: String,
+) -> String {
+    if !settings["transcription"]["removeFillerWords"]
+        .as_bool()
+        .unwrap_or(false)
+    {
+        return text;
+    }
+    let fillers = match crate::storage::load_fillers(app) {
+        Ok(list) => list,
+        Err(_) => return text,
+    };
+    let words: Vec<String> = fillers.into_iter().map(|e| e.word).collect();
+    apply_fillers_to_text(text, &words)
+}
+
+pub(crate) fn apply_fillers_to_text(text: String, fillers: &[String]) -> String {
+    if fillers.is_empty() {
+        return text;
+    }
+    let mut result = text;
+    for filler in fillers {
+        let trimmed = filler.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        let pattern = format!(r"(?i)\b{}\b", regex_escape(trimmed));
+        if let Ok(re) = regex::Regex::new(&pattern) {
+            result = re.replace_all(&result, "").into_owned();
+        }
+    }
+    normalize_after_filler_removal(&result)
+}
+
+fn normalize_after_filler_removal(s: &str) -> String {
+    // Collapse runs of whitespace into single spaces. STT output is typically
+    // single-line so this is safe; preserving multi-line structure would need
+    // a smarter collapse.
+    let collapsed: String = s.split_whitespace().collect::<Vec<_>>().join(" ");
+    // Remove the space before sentence punctuation ("text , word" → "text, word").
+    let mut cleaned = String::with_capacity(collapsed.len());
+    let mut prev: char = ' ';
+    for ch in collapsed.chars() {
+        if matches!(ch, ',' | '.' | '!' | '?' | ';' | ':') && prev == ' ' {
+            cleaned.pop();
+        }
+        cleaned.push(ch);
+        prev = ch;
+    }
+    // Strip orphan punctuation left over when a filler was the first token
+    // (e.g., "Also, ich bin" → after removal "", ich bin" → "ich bin").
+    cleaned
+        .trim()
+        .trim_start_matches(|c: char| {
+            c.is_whitespace() || matches!(c, ',' | ';' | '.' | '!' | '?' | ':')
+        })
+        .trim_start()
+        .to_owned()
+}
+
 pub(crate) fn apply_snippets_to_text(text: String, snippets: &[crate::storage::Snippet]) -> String {
     let enabled: Vec<_> = snippets.iter().filter(|s| s.enabled).collect();
     if enabled.is_empty() {
@@ -758,6 +822,78 @@ mod tests {
 
     fn make_entry(word: &str) -> DictionaryEntry {
         DictionaryEntry { id: "test".into(), word: word.into() }
+    }
+
+    // ── apply_fillers_to_text ─────────────────────────────────────────────────
+
+    #[test]
+    fn fillers_empty_list_returns_text_unchanged() {
+        assert_eq!(apply_fillers_to_text("ich bin müde".into(), &[]), "ich bin müde");
+    }
+
+    #[test]
+    fn fillers_remove_single_whole_word() {
+        let list = vec!["halt".to_string()];
+        assert_eq!(
+            apply_fillers_to_text("ich bin halt müde".into(), &list),
+            "ich bin müde"
+        );
+    }
+
+    #[test]
+    fn fillers_are_case_insensitive() {
+        let list = vec!["also".to_string()];
+        assert_eq!(
+            apply_fillers_to_text("Also, das ist ALSO nicht okay".into(), &list),
+            "das ist nicht okay"
+        );
+    }
+
+    #[test]
+    fn fillers_respect_word_boundaries() {
+        // "so" must not eat "also" or "sort"
+        let list = vec!["so".to_string()];
+        assert_eq!(
+            apply_fillers_to_text("also sprach er so laut".into(), &list),
+            "also sprach er laut"
+        );
+    }
+
+    #[test]
+    fn fillers_remove_multiple_distinct_words() {
+        let list = vec!["um".to_string(), "ähm".to_string()];
+        assert_eq!(
+            apply_fillers_to_text("um ich bin ähm müde".into(), &list),
+            "ich bin müde"
+        );
+    }
+
+    #[test]
+    fn fillers_clean_up_orphaned_punctuation_spacing() {
+        let list = vec!["also".to_string()];
+        assert_eq!(
+            apply_fillers_to_text("ich bin also, müde".into(), &list),
+            "ich bin, müde"
+        );
+    }
+
+    #[test]
+    fn fillers_trim_leading_and_trailing_whitespace() {
+        let list = vec!["also".to_string()];
+        assert_eq!(
+            apply_fillers_to_text("also ich bin müde also".into(), &list),
+            "ich bin müde"
+        );
+    }
+
+    #[test]
+    fn fillers_skip_empty_entries_in_list() {
+        // Empty/whitespace entries in the list must be ignored, not match everything.
+        let list = vec!["".to_string(), "  ".to_string(), "halt".to_string()];
+        assert_eq!(
+            apply_fillers_to_text("ich bin halt müde".into(), &list),
+            "ich bin müde"
+        );
     }
 
     // ── is_auto_language ──────────────────────────────────────────────────────

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -53,7 +53,8 @@
       "transcription": "Transkription",
       "ai": "KI-Nachbearbeitung",
       "snippets": "Snippets",
-      "dictionary": "Wörterbuch"
+      "dictionary": "Wörterbuch",
+      "fillers": "Füllwörter"
     },
     "general": {
       "language": "Sprache",
@@ -144,6 +145,13 @@
       "title": "Wörterbuch",
       "add": "Eintrag hinzufügen",
       "word": "Begriff"
+    },
+    "fillers": {
+      "title": "Füllwörter",
+      "description": "Wörter aus dieser Liste werden vor der KI-Nachbearbeitung aus der Transkription entfernt, wenn der Toggle oben rechts aktiv ist.",
+      "wordPlaceholder": "z. B. also, halt, quasi",
+      "add": "Hinzufügen",
+      "empty": "Noch keine Füllwörter. Typische Kandidaten: also, halt, ja, quasi, sozusagen, irgendwie, eigentlich, um, uh, ähm, like, you know."
     }
   },
   "errors": {

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -53,7 +53,8 @@
       "transcription": "Transcription",
       "ai": "AI Enhancement",
       "snippets": "Snippets",
-      "dictionary": "Dictionary"
+      "dictionary": "Dictionary",
+      "fillers": "Filler Words"
     },
     "general": {
       "language": "Language",
@@ -144,6 +145,13 @@
       "title": "Dictionary",
       "add": "Add entry",
       "word": "Term"
+    },
+    "fillers": {
+      "title": "Filler Words",
+      "description": "Words on this list are stripped from the transcription before AI enhancement runs, when the toggle in the top right is on.",
+      "wordPlaceholder": "e.g. um, uh, like, basically",
+      "add": "Add",
+      "empty": "No filler words yet. Common candidates: um, uh, like, you know, basically, literally, actually, right, so, also, halt, quasi."
     }
   },
   "errors": {

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -6,13 +6,14 @@ import { TranscriptionSettings } from './settings/TranscriptionSettings'
 import { AiSettings } from './settings/AiSettings'
 import { SnippetsSettings } from './settings/SnippetsSettings'
 import { DictionarySettings } from './settings/DictionarySettings'
+import { FillersSettings } from './settings/FillersSettings'
 import { HistoryPage } from './HistoryPage'
 import { StatsPage } from './StatsPage'
 import { DEFAULT_SHORTCUT } from '../types'
 import type { Settings } from '../types'
 import { formatShortcut } from '../shortcut/format'
 
-type NavId = 'history' | 'stats' | 'transcription' | 'ai' | 'snippets' | 'dictionary' | 'general'
+type NavId = 'history' | 'stats' | 'transcription' | 'ai' | 'snippets' | 'dictionary' | 'fillers' | 'general'
 
 interface Props {
   settings: Settings
@@ -65,6 +66,9 @@ export function SettingsPage({ settings, onSave }: Props) {
           <NavItem id="dictionary" active={active} onClick={setActive} icon={<BookIcon />}>
             {t('settings.nav.dictionary')}
           </NavItem>
+          <NavItem id="fillers" active={active} onClick={setActive} icon={<EraserIcon />}>
+            {t('settings.nav.fillers')}
+          </NavItem>
           <NavItem id="general" active={active} onClick={setActive} icon={<SettingsIcon />}>
             {t('settings.nav.general')}
           </NavItem>
@@ -90,6 +94,7 @@ export function SettingsPage({ settings, onSave }: Props) {
           {active === 'ai'            && <AiSettings settings={settings} onChange={handleChange} />}
           {active === 'snippets'      && <SnippetsSettings />}
           {active === 'dictionary'    && <DictionarySettings />}
+          {active === 'fillers'       && <FillersSettings settings={settings} onChange={handleChange} />}
           {active === 'general'       && <GeneralSettings settings={settings} onChange={handleChange} />}
         </div>
       </main>
@@ -147,6 +152,9 @@ function TextIcon() {
 }
 function BookIcon() {
   return <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.25" strokeLinecap="round" strokeLinejoin="round"><path d="M2.5 3v10l2-1h9V3zM4.5 3v9"/></svg>
+}
+function EraserIcon() {
+  return <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.25" strokeLinecap="round" strokeLinejoin="round"><path d="M3.5 11.5l-1 1a1 1 0 0 0 0 1.4l0.6 0.6a1 1 0 0 0 1.4 0l7-7a1 1 0 0 0 0-1.4L9 3a1 1 0 0 0-1.4 0L3.5 7.1z"/><path d="M6 14h8"/></svg>
 }
 function SettingsIcon() {
   return <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.25" strokeLinecap="round"><circle cx="8" cy="8" r="1.5"/><path d="M8 2v1.5M8 12.5V14M13 8h-1.5M4.5 8H3M11.5 4.5l-1 1M5.5 10.5l-1 1M11.5 11.5l-1-1M5.5 5.5l-1-1"/></svg>

--- a/src/pages/settings/FillersSettings.tsx
+++ b/src/pages/settings/FillersSettings.tsx
@@ -1,0 +1,113 @@
+import { useEffect, useRef, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { invoke } from '@tauri-apps/api/core'
+import type { FillerEntry, Settings } from '../../types'
+
+interface Props {
+  settings: Settings
+  onChange: (updated: Settings) => void
+}
+
+export function FillersSettings({ settings, onChange }: Props) {
+  const { t } = useTranslation()
+  const [entries, setEntries] = useState<FillerEntry[]>([])
+  const [input, setInput] = useState('')
+  const inputRef = useRef<HTMLInputElement>(null)
+
+  const enabled = settings.transcription?.removeFillerWords ?? false
+
+  useEffect(() => {
+    invoke<FillerEntry[]>('get_fillers').then(setEntries).catch(console.error)
+  }, [])
+
+  async function persist(updated: FillerEntry[]) {
+    setEntries(updated)
+    await invoke('save_fillers', { entries: updated })
+  }
+
+  async function handleAdd() {
+    const word = input.trim()
+    if (!word) return
+    if (entries.some((e) => e.word.toLowerCase() === word.toLowerCase())) {
+      setInput('')
+      return
+    }
+    await persist([...entries, { id: crypto.randomUUID(), word }])
+    setInput('')
+    inputRef.current?.focus()
+  }
+
+  async function handleDelete(id: string) {
+    await persist(entries.filter((e) => e.id !== id))
+  }
+
+  function toggleEnabled() {
+    onChange({
+      ...settings,
+      transcription: { ...settings.transcription, removeFillerWords: !enabled },
+    })
+  }
+
+  return (
+    <div>
+      <p className="page-eyebrow">einstellungen</p>
+      <div className="flex items-center justify-between" style={{ marginBottom: 14 }}>
+        <h1 className="page-title" style={{ marginBottom: 0 }}>{t('settings.fillers.title')}</h1>
+        <button
+          role="switch"
+          aria-checked={enabled}
+          onClick={toggleEnabled}
+          className={`v-switch${enabled ? ' on' : ''}`}
+        />
+      </div>
+
+      <p className="text-xs text-text-muted mb-4">
+        {t('settings.fillers.description')}
+      </p>
+
+      <div className="flex gap-2 mb-4" style={{ opacity: enabled ? 1 : 0.55 }}>
+        <input
+          ref={inputRef}
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+          onKeyDown={(e) => e.key === 'Enter' && handleAdd()}
+          placeholder={t('settings.fillers.wordPlaceholder')}
+          disabled={!enabled}
+          className="flex-1 px-3 py-1.5 text-sm bg-surface border border-border rounded-lg text-text placeholder:text-text-muted focus:outline-none focus:border-accent disabled:cursor-not-allowed"
+        />
+        <button
+          onClick={handleAdd}
+          disabled={!enabled || !input.trim()}
+          className="px-3 py-1.5 text-xs bg-accent text-accent-fg rounded-lg disabled:opacity-40 disabled:cursor-not-allowed hover:bg-accent-hover transition-colors"
+        >
+          {t('settings.fillers.add')}
+        </button>
+      </div>
+
+      {entries.length > 0 ? (
+        <div className="flex flex-wrap gap-1.5" style={{ opacity: enabled ? 1 : 0.55 }}>
+          {entries.map((entry) => (
+            <div
+              key={entry.id}
+              className="flex items-center gap-1 px-2.5 py-1 rounded-full border border-border bg-surface-raised group"
+            >
+              <span className="text-xs text-text">{entry.word}</span>
+              <button
+                onClick={() => handleDelete(entry.id)}
+                disabled={!enabled}
+                className="text-text-muted hover:text-red-400 transition-colors opacity-0 group-hover:opacity-100 ml-0.5 text-xs leading-none disabled:cursor-not-allowed"
+                aria-label={t('common.delete')}
+              >
+                ×
+              </button>
+            </div>
+          ))}
+        </div>
+      ) : (
+        <p className="text-xs text-text-muted text-center py-8">
+          {t('settings.fillers.empty')}
+        </p>
+      )}
+    </div>
+  )
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -12,6 +12,11 @@ export interface DictionaryEntry {
   word: string
 }
 
+export interface FillerEntry {
+  id: string
+  word: string
+}
+
 export interface AIPrompt {
   id: string
   name: string
@@ -28,6 +33,7 @@ export interface Settings {
     cloudModel: string
     cloudCustomEndpoint: string
     language: TranscriptionLanguage
+    removeFillerWords: boolean
   }
   aiEnhancement: {
     enabled: boolean


### PR DESCRIPTION
  Phase 1 of #6. Introduces a user-managed filler-word list that gets stripped from the raw transcription before AI enhancement. The AI stays filler-agnostic — users own their list per install.
                                                                                                                                                                                                                 
  ## Changes
                                                                                                                                                                                                                 
  **Backend:**                                                                                                                                                                                                   
  - New `fillers.json` storage next to `dictionary.json`, with `FillerEntry` struct, `load_fillers` / `save_fillers` API, tauri commands wired up in `lib.rs`.
  - `transcription.removeFillerWords` setting, default `false` (opt-in only — deletion is destructive, same principle as `privacy.targetAppTracking`). Deep-merge backfills existing installs to `false`.        
  - `apply_fillers_to_text()` in `transcription/mod.rs`: case-insensitive, whole-word regex, normalises whitespace and strips orphan punctuation left when a word at the start of a sentence is removed.         
  - Pipeline: `maybe_remove_fillers` runs between raw STT output and snippet expansion, so AI (if enabled) gets already-clean input.                                                                             
  - Eight new unit tests cover empty list, single + multiple removals, case insensitivity, word boundaries, leading/trailing whitespace, orphan punctuation, empty entries.                                      
                                                                                                                                                                                                                 
  **Frontend:**                                                                                                                                                                                                  
  - New "Füllwörter" / "Filler Words" settings page in the sidebar.                                                                                                                                              
  - Master toggle in the page header (v-switch). When off, the list dims and inputs are disabled — makes the control obvious.                                                                                    
  - Inline word list mirrors the Dictionary page's UX (Enter to add, hover-reveal × to remove).                                                                                                                  
  - Empty state seeds the user with common DE + EN candidates (also, halt, quasi, um, uh, like, you know, basically, literally…).                                                                                
  - `FillerEntry` type and the new settings flag added to the Settings interface.                                                                                                                                
  - DE + EN i18n keys for title, description, placeholder, add button, empty state.                                                                                                                              
                                                                                                                                                                                                                 
  ## Out of scope (Phase 2)                                                                                                                                                                                      
                                                                                                                                                                                                                 
  - **Auto-detected suggestions from transcript history.** Needs a ranker against `history.json` plus an accept/reject UX with memory of past rejections. Separate PR.                                           
  
  ## Test plan                                                                                                                                                                                                   
                                                            
  - [ ] Toggle ON, add "halt" to the list, dictate "ich bin halt müde" → paste shows "ich bin müde"                                                                                                              
  - [ ] Toggle OFF with words in the list → no filtering happens
  - [ ] Add "also" to list, dictate "Also, das ist okay" → paste shows "das ist okay" (leading comma stripped)                                                                                                   
  - [ ] Dictate "also sprach er" with "so" on the list → "also sprach er" is preserved (word boundary works)                                                                                                     
  - [ ] Fresh install without any `fillers.json` → empty list, toggle OFF, no errors                                                                                                                             
                                                                                                                                                                                                                 
  Part of #6 (manual-list path; auto-detection is Phase 2).