### PR TITLE
feat: mute other apps while recording (Windows)

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -43,6 +43,8 @@ windows = { version = "0.58", features = [
     "Win32_Foundation",
     "Win32_System_Threading",
     "Win32_UI_WindowsAndMessaging",
+    "Win32_Media_Audio",
+    "Win32_System_Com",
 ] }
 
 [target.'cfg(target_os = "macos")'.dependencies]

--- a/src-tauri/src/audio_ducking/mod.rs
+++ b/src-tauri/src/audio_ducking/mod.rs
@@ -1,0 +1,188 @@
+// Mute other applications' audio output while VOCA is recording, then
+// restore the previous state when recording stops. Windows only for now —
+// macOS has no clean per-app mute API and is tracked separately.
+//
+// Design note: we only carry plain PIDs across the mute→restore boundary,
+// never COM objects. Each Win32 call initialises its own COM context and
+// enumerates fresh, which keeps things thread-apartment-agnostic and
+// avoids Send/Sync headaches.
+
+pub struct DuckingGuard {
+    #[cfg(target_os = "windows")]
+    muted_pids: Vec<u32>,
+    #[cfg(not(target_os = "windows"))]
+    _phantom: (),
+}
+
+impl DuckingGuard {
+    fn empty() -> Self {
+        Self {
+            #[cfg(target_os = "windows")]
+            muted_pids: Vec::new(),
+            #[cfg(not(target_os = "windows"))]
+            _phantom: (),
+        }
+    }
+}
+
+pub fn mute_others() -> DuckingGuard {
+    #[cfg(target_os = "windows")]
+    {
+        match windows_impl::mute() {
+            Ok(pids) => DuckingGuard { muted_pids: pids },
+            Err(e) => {
+                log::warn!("audio ducking: mute failed: {e}");
+                DuckingGuard::empty()
+            }
+        }
+    }
+    #[cfg(not(target_os = "windows"))]
+    {
+        DuckingGuard::empty()
+    }
+}
+
+pub fn restore(guard: DuckingGuard) {
+    #[cfg(target_os = "windows")]
+    {
+        if guard.muted_pids.is_empty() {
+            return;
+        }
+        if let Err(e) = windows_impl::restore(&guard.muted_pids) {
+            log::warn!("audio ducking: restore failed: {e}");
+        }
+    }
+    #[cfg(not(target_os = "windows"))]
+    {
+        drop(guard);
+    }
+}
+
+#[cfg(target_os = "windows")]
+mod windows_impl {
+    use windows::core::Interface;
+    use windows::Win32::Media::Audio::{
+        eMultimedia, eRender, IAudioSessionControl2, IAudioSessionManager2, IMMDevice,
+        IMMDeviceEnumerator, ISimpleAudioVolume, MMDeviceEnumerator,
+    };
+    use windows::Win32::System::Com::{
+        CoCreateInstance, CoInitializeEx, CLSCTX_ALL, COINIT_MULTITHREADED,
+    };
+
+    pub fn mute() -> Result<Vec<u32>, String> {
+        unsafe {
+            // CoInitializeEx is idempotent per-thread; RPC_E_CHANGED_MODE means
+            // another apartment is already set, which is fine for our usage
+            // since every call re-creates its own COM objects.
+            let _ = CoInitializeEx(None, COINIT_MULTITHREADED);
+
+            let enumerator: IMMDeviceEnumerator =
+                CoCreateInstance(&MMDeviceEnumerator, None, CLSCTX_ALL)
+                    .map_err(|e| format!("IMMDeviceEnumerator: {e}"))?;
+
+            let device: IMMDevice = enumerator
+                .GetDefaultAudioEndpoint(eRender, eMultimedia)
+                .map_err(|e| format!("GetDefaultAudioEndpoint: {e}"))?;
+
+            let manager: IAudioSessionManager2 = device
+                .Activate(CLSCTX_ALL, None)
+                .map_err(|e| format!("Activate IAudioSessionManager2: {e}"))?;
+
+            let session_enum = manager
+                .GetSessionEnumerator()
+                .map_err(|e| format!("GetSessionEnumerator: {e}"))?;
+
+            let count = session_enum
+                .GetCount()
+                .map_err(|e| format!("GetCount: {e}"))?;
+
+            let our_pid = std::process::id();
+            let mut muted: Vec<u32> = Vec::new();
+
+            for i in 0..count {
+                let control = match session_enum.GetSession(i) {
+                    Ok(c) => c,
+                    Err(_) => continue,
+                };
+                let control2 = match control.cast::<IAudioSessionControl2>() {
+                    Ok(c) => c,
+                    Err(_) => continue,
+                };
+                let pid = match control2.GetProcessId() {
+                    Ok(p) => p,
+                    Err(_) => continue,
+                };
+                if pid == 0 || pid == our_pid {
+                    continue;
+                }
+                let volume = match control.cast::<ISimpleAudioVolume>() {
+                    Ok(v) => v,
+                    Err(_) => continue,
+                };
+                // Already-muted sessions aren't ours to touch — leave them
+                // alone so we don't "un-mute" a session the user muted
+                // deliberately.
+                let was_muted = volume.GetMute().unwrap_or_default();
+                if was_muted.as_bool() {
+                    continue;
+                }
+                if volume.SetMute(true, std::ptr::null()).is_ok() {
+                    muted.push(pid);
+                }
+            }
+
+            Ok(muted)
+        }
+    }
+
+    pub fn restore(pids: &[u32]) -> Result<(), String> {
+        unsafe {
+            let _ = CoInitializeEx(None, COINIT_MULTITHREADED);
+
+            let enumerator: IMMDeviceEnumerator =
+                CoCreateInstance(&MMDeviceEnumerator, None, CLSCTX_ALL)
+                    .map_err(|e| format!("IMMDeviceEnumerator: {e}"))?;
+
+            let device: IMMDevice = enumerator
+                .GetDefaultAudioEndpoint(eRender, eMultimedia)
+                .map_err(|e| format!("GetDefaultAudioEndpoint: {e}"))?;
+
+            let manager: IAudioSessionManager2 = device
+                .Activate(CLSCTX_ALL, None)
+                .map_err(|e| format!("Activate IAudioSessionManager2: {e}"))?;
+
+            let session_enum = manager
+                .GetSessionEnumerator()
+                .map_err(|e| format!("GetSessionEnumerator: {e}"))?;
+
+            let count = session_enum
+                .GetCount()
+                .map_err(|e| format!("GetCount: {e}"))?;
+
+            for i in 0..count {
+                let control = match session_enum.GetSession(i) {
+                    Ok(c) => c,
+                    Err(_) => continue,
+                };
+                let control2 = match control.cast::<IAudioSessionControl2>() {
+                    Ok(c) => c,
+                    Err(_) => continue,
+                };
+                let pid = match control2.GetProcessId() {
+                    Ok(p) => p,
+                    Err(_) => continue,
+                };
+                if !pids.contains(&pid) {
+                    continue;
+                }
+                let volume = match control.cast::<ISimpleAudioVolume>() {
+                    Ok(v) => v,
+                    Err(_) => continue,
+                };
+                let _ = volume.SetMute(false, std::ptr::null());
+            }
+
+            Ok(())
+        }
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod ai;
 pub mod audio;
+pub mod audio_ducking;
 pub mod clipboard;
 pub mod commands;
 pub mod errors;
@@ -40,6 +41,7 @@ pub struct LastPressTime(pub Mutex<Option<std::time::Instant>>);
 pub struct LastTapTime(pub Mutex<Option<std::time::Instant>>);
 pub struct IsToggleSession(pub Mutex<bool>);
 pub struct SelectedAudioDevice(pub Mutex<Option<String>>);
+pub struct AudioDuckingState(pub Mutex<Option<audio_ducking::DuckingGuard>>);
 pub struct DownloadCancelFlag(pub Arc<Mutex<bool>>);
 pub struct HotkeyStateWrapper(pub std::sync::Arc<hotkey::HotkeyState>);
 
@@ -86,6 +88,7 @@ pub fn run() {
         .manage(LastTapTime(Mutex::new(None)))
         .manage(IsToggleSession(Mutex::new(false)))
         .manage(SelectedAudioDevice(Mutex::new(None)))
+        .manage(AudioDuckingState(Mutex::new(None)))
         .manage(DownloadCancelFlag(Arc::new(Mutex::new(false))))
         .manage(HotkeyStateWrapper(Arc::new(hotkey::HotkeyState::new())))
         .setup(|app| {

--- a/src-tauri/src/shortcut/mod.rs
+++ b/src-tauri/src/shortcut/mod.rs
@@ -3,7 +3,8 @@ use tauri::{AppHandle, Emitter, Manager};
 
 use crate::{
     audio::{AudioBuffer, AudioRecordingState},
-    AppState, AppStateManager, RecordingStateChangedPayload, SelectedAudioDevice,
+    AppState, AppStateManager, AudioDuckingState, RecordingStateChangedPayload,
+    SelectedAudioDevice,
 };
 
 pub const DEFAULT_SHORTCUT: &str = "Ctrl+Super";
@@ -105,6 +106,7 @@ fn start_recording(app: &AppHandle) {
         crate::errors::transition_to_error(app);
         return;
     }
+    maybe_duck_audio(app);
     let manager = app.state::<AppStateManager>();
     *manager.0.lock().unwrap() = AppState::Recording;
     emit_state(app, AppState::Recording);
@@ -114,6 +116,7 @@ fn stop_recording(app: &AppHandle) {
     let audio = app.state::<AudioRecordingState>();
     match crate::audio::stop(&audio) {
         Ok(wav_bytes) => {
+            restore_ducked_audio(app);
             *app.state::<AudioBuffer>().0.lock().unwrap() = Some(wav_bytes);
             let manager = app.state::<AppStateManager>();
             *manager.0.lock().unwrap() = AppState::Processing;
@@ -124,6 +127,7 @@ fn stop_recording(app: &AppHandle) {
             });
         }
         Err(e) => {
+            restore_ducked_audio(app);
             crate::errors::emit(app, "RECORDING_FAILED", &e);
             crate::errors::transition_to_error(app);
         }
@@ -136,6 +140,7 @@ fn cancel_recording(app: &AppHandle) {
     // keeps the UI pill showing continuously (no Recording→Idle→Recording flash).
     let audio = app.state::<AudioRecordingState>();
     let _ = crate::audio::stop(&audio);
+    restore_ducked_audio(app);
     let manager = app.state::<AppStateManager>();
     *manager.0.lock().unwrap() = AppState::Idle;
 
@@ -152,4 +157,23 @@ fn cancel_recording(app: &AppHandle) {
 fn emit_state(app: &AppHandle, state: AppState) {
     crate::update_tray_icon(app, &state);
     let _ = app.emit("recording-state-changed", RecordingStateChangedPayload { state });
+}
+
+fn maybe_duck_audio(app: &AppHandle) {
+    let settings = crate::storage::load(app).unwrap_or_default();
+    let enabled = settings["transcription"]["muteOtherAudio"]
+        .as_bool()
+        .unwrap_or(true);
+    if !enabled {
+        return;
+    }
+    let guard = crate::audio_ducking::mute_others();
+    *app.state::<AudioDuckingState>().0.lock().unwrap() = Some(guard);
+}
+
+fn restore_ducked_audio(app: &AppHandle) {
+    let guard = app.state::<AudioDuckingState>().0.lock().unwrap().take();
+    if let Some(g) = guard {
+        crate::audio_ducking::restore(g);
+    }
 }

--- a/src-tauri/src/storage/mod.rs
+++ b/src-tauri/src/storage/mod.rs
@@ -245,7 +245,8 @@ pub(crate) fn defaults() -> serde_json::Value {
             "cloudModel": "",
             "cloudCustomEndpoint": "",
             "language": "auto",
-            "removeFillerWords": false
+            "removeFillerWords": false,
+            "muteOtherAudio": true
         },
         "aiEnhancement": {
             "enabled": false,
@@ -324,6 +325,23 @@ mod tests {
         // Opt-in only — deletion is destructive, same principle as
         // privacy.targetAppTracking.
         assert_eq!(defaults()["transcription"]["removeFillerWords"], false);
+    }
+
+    #[test]
+    fn defaults_mute_other_audio_is_on() {
+        // Ducking is expected behaviour per the feature brief — mirrors how
+        // Whisperflow/VoiceInk ship. Users can opt out in Transcription
+        // settings if they want other audio to keep playing during recording.
+        assert_eq!(defaults()["transcription"]["muteOtherAudio"], true);
+    }
+
+    #[test]
+    fn merge_fills_missing_mute_other_audio_flag_with_true() {
+        let loaded = serde_json::json!({
+            "transcription": { "mode": "cloud" }
+        });
+        let merged = merge_defaults(loaded, defaults());
+        assert_eq!(merged["transcription"]["muteOtherAudio"], true);
     }
 
     #[test]

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -93,6 +93,8 @@
         "pt": "Português",
         "it": "Italiano"
       },
+      "muteOtherAudio": "Andere Apps während Aufnahme stummschalten",
+      "muteOtherAudioDescription": "Stummt laufende Audio-Ausgabe anderer Programme (z. B. Musik, Videos) während einer Aufnahme. Nichts wird pausiert. Aktuell nur Windows.",
       "apiKey": "API Key",
       "localModel": "Lokales Modell",
       "localModelDescription": "Läuft vollständig auf deinem Gerät – kein Internet nötig",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -93,6 +93,8 @@
         "pt": "Português",
         "it": "Italiano"
       },
+      "muteOtherAudio": "Mute other apps while recording",
+      "muteOtherAudioDescription": "Silences audio from other programs (music, videos, etc.) during recording. Nothing is paused. Windows only for now.",
       "apiKey": "API Key",
       "localModel": "Local model",
       "localModelDescription": "Runs entirely on your device – no internet required",

--- a/src/pages/settings/TranscriptionSettings.tsx
+++ b/src/pages/settings/TranscriptionSettings.tsx
@@ -173,6 +173,11 @@ export function TranscriptionSettings({ settings, onChange }: Props) {
     onChange({ ...settings, transcription: { ...settings.transcription, language } })
   }
 
+  function toggleMuteOtherAudio() {
+    const next = !(settings.transcription.muteOtherAudio ?? true)
+    onChange({ ...settings, transcription: { ...settings.transcription, muteOtherAudio: next } })
+  }
+
   function handleModelSizeChange(size: ModelSize) {
     onChange({ ...settings, transcription: { ...settings.transcription, localModelSize: size } })
   }
@@ -248,6 +253,18 @@ export function TranscriptionSettings({ settings, onChange }: Props) {
             </option>
           ))}
         </select>
+      </SettingRow>
+
+      <SettingRow
+        label={t('settings.transcription.muteOtherAudio')}
+        description={t('settings.transcription.muteOtherAudioDescription')}
+      >
+        <button
+          role="switch"
+          aria-checked={settings.transcription.muteOtherAudio ?? true}
+          onClick={toggleMuteOtherAudio}
+          className={`v-switch${(settings.transcription.muteOtherAudio ?? true) ? ' on' : ''}`}
+        />
       </SettingRow>
 
       {!isLocal && (

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -34,6 +34,7 @@ export interface Settings {
     cloudCustomEndpoint: string
     language: TranscriptionLanguage
     removeFillerWords: boolean
+    muteOtherAudio: boolean
   }
   aiEnhancement: {
     enabled: boolean


### PR DESCRIPTION
  Adds a Windows-only audio ducking layer that silences other applications' audio output for the duration of a recording and restores it when recording stops. Matches how Whisperflow and VoiceInk ship. macOS  
  has no clean per-app mute API — tracked separately as a follow-up, not part of this PR.                                                                                                                        
                                                                                                                                                                                                                 
  ## Changes                                                                                                                                                                                                     
                                                                  
  **Backend:**                                                                                                                                                                                                   
  - New `audio_ducking` module with cross-platform `DuckingGuard` and `mute_others()` / `restore()` API. Non-Windows is a no-op.
  - Windows implementation uses WASAPI: `IMMDeviceEnumerator` → `IAudioSessionManager2` → per-session `ISimpleAudioVolume::SetMute`. Skips our own PID, skips sessions that are already muted (so we don't       
  "un-mute" apps the user silenced manually).                                                                                                                                                                    
  - Design note: only plain PIDs cross the mute/restore boundary, never COM objects. Each Win32 call initialises its own COM context and enumerates fresh — apartment-agnostic, no Send/Sync gymnastics.         
  - New `AudioDuckingState` managed state in `lib.rs` holds the guard between start and stop.                                                                                                                    
  - Hooks in `shortcut/mod.rs`: ducking starts after `audio::start` succeeds, restores on stop / error / cancel. Failures are logged, never block recording.                                                     
  - `transcription.muteOtherAudio` flag, default `true`. Deep-merge backfills existing installs.                                                                                                                 
  - Cargo.toml gains `Win32_Media_Audio` + `Win32_System_Com` features on the Windows target.                                                                                                                    
                                                                                                                                                                                                                 
  **Frontend:**                                                                                                                                                                                                  
  - Toggle row in Transcription settings, directly below the language row.                                                                                                                                       
  - Copy is explicit: audio is **muted** (not paused), and the feature is Windows-only for now.                                                                                                                  
  - DE + EN i18n keys.                                                                                                                                                                                           
  - Type and default added to `Settings.transcription`.                                                                                                                                                          
                                                                                                                                                                                                                 
  ## Out of scope                                                 
                                                                                                                                                                                                                 
  - **macOS implementation.** No native per-app mute API exists. Tracked as a separate follow-up issue once this merges.                                                                                         
  - **Windows CI compile check.** CI is currently Linux-only. The Windows-gated code is not auto-verified in CI; relied on local Windows build for this PR. A `cargo check` job on `windows-latest` would be a
  cheap follow-up.                                                                                                                                                                                               
                                                                  
  ## Test plan                                                                                                                                                                                                   
                                                                  
  Tested locally on Windows — all green:                                                                                                                                                                         
                                                                  
  - [x] Play a YouTube video, trigger recording (toggle ON) → video audio goes silent, video keeps playing                                                                                                       
  - [x] Stop recording → video audio returns at previous level
  - [x] Cancel recording via quick-tap → audio restores                                                                                                                                                          
  - [x] Toggle OFF, trigger recording → no audio is touched                                                                                                                                                      
  - [x] Fresh install → `muteOtherAudio` defaults to `true`; existing install without the key gets backfilled to `true`                                                                                          
                                                                                                                                                                                                                 
  Part of #29. Does not close the issue — macOS follow-up to be filed after merge.