### PR TITLE
feat: pill reveals on test step, stays dormant during early onboarding

### DIFF
--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -82,7 +82,47 @@ pub fn save_settings(
     app: tauri::AppHandle,
     settings: serde_json::Value,
 ) -> Result<(), String> {
-    storage::save(&app, &settings)
+    // Intercept the onboardingCompleted transition from false → true. This
+    // covers every completion path (Done step, skip button, closing the
+    // window mid-flow) in one spot so frontend callers don't have to
+    // remember to unlock the gate and show the pill themselves.
+    let prev = storage::load(&app).ok();
+    let was_done = prev
+        .as_ref()
+        .and_then(|s| s["general"]["onboardingCompleted"].as_bool())
+        .unwrap_or(false);
+    let is_done = settings["general"]["onboardingCompleted"]
+        .as_bool()
+        .unwrap_or(false);
+
+    storage::save(&app, &settings)?;
+
+    if !was_done && is_done {
+        // Completion just happened — unlock recording and reveal pill if it
+        // was hidden. We don't animate here; this path is for users who
+        // skipped past the Test step. The animated reveal only fires via
+        // the `pill-animate-reveal` event from the Test step mount.
+        *app.state::<crate::RecordingGate>().0.lock().unwrap() = true;
+        if let Some(pill) = app.get_webview_window("status-bar") {
+            let _ = pill.show();
+        }
+    }
+
+    Ok(())
+}
+
+#[tauri::command]
+pub fn unlock_recording(app: tauri::AppHandle) -> Result<(), String> {
+    *app.state::<crate::RecordingGate>().0.lock().unwrap() = true;
+    Ok(())
+}
+
+#[tauri::command]
+pub fn show_pill(app: tauri::AppHandle) -> Result<(), String> {
+    if let Some(pill) = app.get_webview_window("status-bar") {
+        pill.show().map_err(|e| e.to_string())?;
+    }
+    Ok(())
 }
 
 #[tauri::command]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -42,6 +42,13 @@ pub struct LastTapTime(pub Mutex<Option<std::time::Instant>>);
 pub struct IsToggleSession(pub Mutex<bool>);
 pub struct SelectedAudioDevice(pub Mutex<Option<String>>);
 pub struct AudioDuckingState(pub Mutex<Option<audio_ducking::DuckingGuard>>);
+
+/// Blocks recording + pill visibility during early onboarding steps.
+/// `false` = gated (ignore shortcut presses, pill window hidden);
+/// `true` = normal operation. Set at startup from `general.onboardingCompleted`,
+/// flipped to `true` by the frontend when the onboarding Test step mounts
+/// (or when onboarding completes by any path).
+pub struct RecordingGate(pub Mutex<bool>);
 pub struct DownloadCancelFlag(pub Arc<Mutex<bool>>);
 pub struct HotkeyStateWrapper(pub std::sync::Arc<hotkey::HotkeyState>);
 
@@ -89,6 +96,7 @@ pub fn run() {
         .manage(IsToggleSession(Mutex::new(false)))
         .manage(SelectedAudioDevice(Mutex::new(None)))
         .manage(AudioDuckingState(Mutex::new(None)))
+        .manage(RecordingGate(Mutex::new(true))) // default; setup() reconciles from settings
         .manage(DownloadCancelFlag(Arc::new(Mutex::new(false))))
         .manage(HotkeyStateWrapper(Arc::new(hotkey::HotkeyState::new())))
         .setup(|app| {
@@ -114,6 +122,20 @@ pub fn run() {
                 hotkey::start(hotkey_state, handle.clone());
             }
 
+            // Reconcile the RecordingGate + pill visibility against persisted
+            // onboarding state. On first-run installs (onboardingCompleted =
+            // false) we gate everything until the user reaches the Test step;
+            // on every subsequent launch the pill is normal from the first
+            // frame.
+            let onboarding_done = {
+                let handle = app.handle();
+                let settings = crate::storage::load(handle).unwrap_or_default();
+                settings["general"]["onboardingCompleted"]
+                    .as_bool()
+                    .unwrap_or(false)
+            };
+            *app.state::<RecordingGate>().0.lock().unwrap() = onboarding_done;
+
             if let Some(status_bar) = app.get_webview_window("status-bar") {
                 // Prefer primary_monitor for reliable startup positioning;
                 // the monitor's .position() offset is added so multi-monitor
@@ -125,6 +147,9 @@ pub fn run() {
                     .or_else(|| status_bar.current_monitor().ok().flatten());
                 if let Some(m) = monitor {
                     position_status_bar(&status_bar, &m);
+                }
+                if !onboarding_done {
+                    let _ = status_bar.hide();
                 }
             }
 
@@ -194,6 +219,8 @@ pub fn run() {
             commands::set_window_theme,
             commands::list_audio_devices,
             commands::set_audio_device,
+            commands::unlock_recording,
+            commands::show_pill,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src-tauri/src/shortcut/mod.rs
+++ b/src-tauri/src/shortcut/mod.rs
@@ -3,8 +3,8 @@ use tauri::{AppHandle, Emitter, Manager};
 
 use crate::{
     audio::{AudioBuffer, AudioRecordingState},
-    AppState, AppStateManager, AudioDuckingState, RecordingStateChangedPayload,
-    SelectedAudioDevice,
+    AppState, AppStateManager, AudioDuckingState, RecordingGate,
+    RecordingStateChangedPayload, SelectedAudioDevice,
 };
 
 pub const DEFAULT_SHORTCUT: &str = "Ctrl+Super";
@@ -20,6 +20,15 @@ const ON_PRESS_DEDUP: Duration = Duration::from_millis(50);
 
 /// Called by hotkey::start when the shortcut keys are all pressed.
 pub fn on_press(app: &AppHandle) {
+    // Gate during early onboarding: before the user has reached the Test
+    // step (or completed onboarding otherwise), pressing the shortcut must
+    // be a no-op. The listener stays alive in the background so we don't
+    // have to re-register anything when the gate opens.
+    if !*app.state::<RecordingGate>().0.lock().unwrap() {
+        eprintln!("[VOCA shortcut] on_press ignored (recording gate locked)");
+        return;
+    }
+
     // Dedup against double-firing from rdev + frontend fallback.
     {
         let press_state = app.state::<crate::LastPressTime>();

--- a/src-tauri/src/stats/mod.rs
+++ b/src-tauri/src/stats/mod.rs
@@ -224,7 +224,17 @@ mod tests {
     }
 
     fn now_ms() -> i64 {
-        Local::now().timestamp_millis()
+        // Fixed anchor at 12:00 UTC on 2026-04-23 (a Thursday). Using
+        // Local::now() made every time-bucket test flaky on CI: whenever
+        // the runner fired within the first hour after midnight UTC, an
+        // entry stamped "1 h ago" landed on yesterday's calendar date and
+        // the `words_today` / `activity_30d[29]` assertions flipped to
+        // zero. A fixed mid-day UTC anchor keeps the ±hour offsets we
+        // use in these tests inside the same local date regardless of
+        // when the runner fires or which timezone it inherits.
+        chrono::DateTime::parse_from_rfc3339("2026-04-23T12:00:00Z")
+            .expect("valid rfc3339 anchor")
+            .timestamp_millis()
     }
 
     fn day_ms() -> u64 {

--- a/src/StatusBar.tsx
+++ b/src/StatusBar.tsx
@@ -62,27 +62,9 @@ export default function StatusBar() {
     return () => { unlisten.then((fn) => fn()) }
   }, [])
 
-  // Reveal ceremony: fires once per onboarding completion. Diagnostic
-  // logging included while we track down why production builds weren't
-  // showing the animation.
+  // Reveal ceremony: fires once per onboarding completion.
   useEffect(() => {
-    // eslint-disable-next-line no-console
-    console.log('[voca-pill] status bar mounted, registering pill-animate-reveal listener')
     const unlisten = listen<{ bubble?: string }>('pill-animate-reveal', (e) => {
-      // eslint-disable-next-line no-console
-      console.log('[voca-pill] pill-animate-reveal event received', e.payload)
-
-      // Diagnostic: unmistakable visible marker — if the user doesn't see
-      // this yellow tag appear in the pill window for 3 seconds, the event
-      // isn't reaching the listener at all (or the listener isn't mounted
-      // yet when the event fires).
-      const marker = document.createElement('div')
-      marker.textContent = 'EVENT OK'
-      marker.style.cssText =
-        'position:fixed;top:4px;left:4px;background:#FFD600;color:#111;padding:3px 8px;z-index:99999;font-size:10px;font-family:sans-serif;font-weight:700;border-radius:3px;pointer-events:none;'
-      document.body.appendChild(marker)
-      setTimeout(() => marker.remove(), 3000)
-
       const text = e.payload?.bubble ?? null
       if (text) {
         setBubbleText(text)
@@ -99,8 +81,6 @@ export default function StatusBar() {
       // Reset and schedule the attention wiggle.
       if (wiggleTimerRef.current) clearTimeout(wiggleTimerRef.current)
       wiggleTimerRef.current = setTimeout(() => {
-        // eslint-disable-next-line no-console
-        console.log('[voca-pill] wiggle timer fired')
         playWiggleAnimation()
       }, WIGGLE_AFTER_MS)
     })
@@ -112,65 +92,55 @@ export default function StatusBar() {
   }, [])
 
   function playRevealAnimation() {
-    // eslint-disable-next-line no-console
-    console.log('[voca-pill] playRevealAnimation fired')
     const outer = outerRef.current
     const content = contentRef.current
-    // eslint-disable-next-line no-console
-    console.log('[voca-pill] refs attached — outer:', !!outer, 'content:', !!content)
     if (!content) return
 
-    if (prefersReducedMotion()) {
-      // eslint-disable-next-line no-console
-      console.log('[voca-pill] prefers-reduced-motion is on, skipping animation')
-      return
-    }
+    const reduceMotion = prefersReducedMotion()
 
-    // --- Diagnostic flash ------------------------------------------------
-    // Regardless of what happens with the structured animation below,
-    // briefly flip the pill's outline to hot magenta for 1.5 s. If the
-    // user doesn't see this, the event isn't reaching the listener OR the
-    // ref isn't bound to the right element — both require dev-mode
-    // debugging. If they DO see it, animations work but our staging has
-    // issues.
-    content.style.outline = '3px solid magenta'
-    content.style.outlineOffset = '6px'
-    setTimeout(() => {
-      if (content) {
-        content.style.outline = ''
-        content.style.outlineOffset = ''
-      }
-    }, 1500)
-
-    // --- Simplified reveal: scale + ember glow -------------------------
-    // Earlier iterations tried outer-wrapper rotation + multi-stage
-    // transforms; something in the production webview kept discarding
-    // them. Pared down to the most basic possible transition: content
-    // snaps to a larger, ember-coloured state, then transitions back to
-    // rest. Uses getBoundingClientRect() for the reflow (more reliable
-    // than offsetHeight in some WebView2 builds).
+    // Starting pose: pill is invisible and flooded with the ember accent
+    // colour. We paint this synchronously, force a reflow, then queue the
+    // transition to rest. Without the reflow the browser coalesces the
+    // two style writes into a single paint and the user sees nothing.
     content.style.transition = 'none'
     content.style.backgroundColor = EMBER
     content.style.boxShadow = EMBER_SHADOW
 
     if (outer) {
       outer.style.transition = 'none'
-      outer.style.transformOrigin = 'center bottom'
-      outer.style.transform = 'scale(0.3)'
+      outer.style.opacity = '0'
+      if (!reduceMotion) {
+        // Only add the bouncy scale/rotate for users who want motion.
+        // The reduced-motion variant is a pure opacity + colour fade.
+        outer.style.transformOrigin = 'center bottom'
+        outer.style.transform = 'scale(0.3) rotate(-140deg)'
+      }
     }
 
+    // getBoundingClientRect is a more reliable reflow trigger than
+    // offsetHeight in some WebView2 builds.
     content.getBoundingClientRect()
 
     requestAnimationFrame(() => {
+      // Content: ember → normal dark. Same for both motion variants.
       content.style.transition =
         'background-color 700ms ease-out, box-shadow 700ms ease-out'
       content.style.backgroundColor = PILL_COLLAPSED_BG
       content.style.boxShadow = PILL_COLLAPSED_SHADOW
 
       if (outer) {
-        outer.style.transition =
-          'transform 700ms cubic-bezier(0.34, 1.56, 0.64, 1)'
-        outer.style.transform = 'scale(1)'
+        if (reduceMotion) {
+          // Gentle fade-in, no transforms.
+          outer.style.transition = 'opacity 480ms ease-out'
+          outer.style.opacity = '1'
+        } else {
+          // Full swoop: scale and un-rotate into place with a spring
+          // overshoot, while opacity eases in quickly.
+          outer.style.transition =
+            'transform 700ms cubic-bezier(0.34, 1.56, 0.64, 1), opacity 280ms ease-out'
+          outer.style.transform = 'scale(1) rotate(0)'
+          outer.style.opacity = '1'
+        }
       }
     })
 
@@ -181,6 +151,7 @@ export default function StatusBar() {
       if (outer) {
         outer.style.transition = ''
         outer.style.transform = ''
+        outer.style.opacity = ''
         outer.style.transformOrigin = ''
       }
     }, 820)

--- a/src/StatusBar.tsx
+++ b/src/StatusBar.tsx
@@ -22,7 +22,7 @@ const WAVE_BARS = 14
 // WIGGLE_AFTER_MS, the pill does a single attention wiggle. Wiggle comes
 // early enough that it reliably fires before most users have stopped
 // reading the onboarding copy; the bubble survives through the wiggle.
-const REVEAL_POP_MS = 780
+const REVEAL_POP_MS = 820
 const BUBBLE_MS = 12000
 const WIGGLE_AFTER_MS = 7000
 const WIGGLE_DURATION_MS = 900
@@ -59,10 +59,19 @@ export default function StatusBar() {
   // never has to own its own i18n state.
   useEffect(() => {
     const unlisten = listen<{ bubble?: string }>('pill-animate-reveal', (e) => {
-      setRevealing(true)
-      // Drop the revealing flag after the pop-in animation ends so the
-      // keyframe class doesn't restart on unrelated re-renders.
-      setTimeout(() => setRevealing(false), REVEAL_POP_MS)
+      // Force a fresh CSS animation run: clear the class, wait two frames
+      // (one for React to commit the DOM change, one for the browser to
+      // acknowledge the style recalculation), then re-apply. Without this
+      // the keyframe is frequently skipped when the pill's webview has
+      // just been made visible from a hidden state — Tauri/OS compositor
+      // has a brief window where animation frames get swallowed.
+      setRevealing(false)
+      requestAnimationFrame(() => {
+        requestAnimationFrame(() => {
+          setRevealing(true)
+          setTimeout(() => setRevealing(false), REVEAL_POP_MS)
+        })
+      })
 
       const text = e.payload?.bubble ?? null
       if (text) {

--- a/src/StatusBar.tsx
+++ b/src/StatusBar.tsx
@@ -19,13 +19,22 @@ const WAVE_BARS = 14
 // Timings for the first-run reveal ceremony — shown once when the onboarding
 // Test step mounts. Bubble auto-dismisses after BUBBLE_MS or on the first
 // actual recording, whichever comes first. If the user stays idle for
-// WIGGLE_AFTER_MS, the pill does a single attention wiggle. Wiggle comes
-// early enough that it reliably fires before most users have stopped
-// reading the onboarding copy; the bubble survives through the wiggle.
+// WIGGLE_AFTER_MS, the pill does a single attention wiggle.
 const REVEAL_POP_MS = 820
 const BUBBLE_MS = 12000
 const WIGGLE_AFTER_MS = 7000
 const WIGGLE_DURATION_MS = 900
+
+const EMBER = '#C65441'
+const PILL_COLLAPSED_BG = 'rgba(30,30,30,0.55)'
+const PILL_COLLAPSED_SHADOW =
+  '0 1px 4px rgba(0,0,0,0.35), 0 0 0 0.5px rgba(255,255,255,0.12)'
+const EMBER_SHADOW =
+  '0 0 42px 18px rgba(198,84,65,0.6), 0 0 0 0.5px rgba(255,255,255,0.15)'
+
+const prefersReducedMotion = () =>
+  typeof window !== 'undefined' &&
+  window.matchMedia?.('(prefers-reduced-motion: reduce)').matches
 
 export default function StatusBar() {
   const { t } = useTranslation()
@@ -35,12 +44,12 @@ export default function StatusBar() {
   const startRef = useRef<number | null>(null)
   const timerRef = useRef<ReturnType<typeof setInterval> | null>(null)
 
-  // First-run reveal state
-  const [revealing, setRevealing] = useState(false)
+  // Reveal ceremony state
   const [bubbleText, setBubbleText] = useState<string | null>(null)
-  const [wiggle, setWiggle] = useState(false)
   const bubbleTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const wiggleTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const outerRef = useRef<HTMLDivElement | null>(null)
+  const contentRef = useRef<HTMLDivElement | null>(null)
 
   useEffect(() => {
     getCurrentWebviewWindow().setIgnoreCursorEvents(true).catch(() => {})
@@ -54,25 +63,15 @@ export default function StatusBar() {
     return () => { unlisten.then((fn) => fn()) }
   }, [])
 
-  // Reveal ceremony: fires once per onboarding completion. Payload carries
-  // the bubble text in whatever locale the main window is using, so the pill
-  // never has to own its own i18n state.
+  // Reveal ceremony: fires once per onboarding completion. We drive both
+  // the outer swoop and the child's ember-to-dark colour transition via
+  // the Web Animations API instead of CSS classes — CSS keyframes were
+  // being swallowed by the OS compositor in the first ~200 ms after the
+  // hidden webview became visible, so the user saw the pill appear with
+  // no motion. Imperative .animate() bypasses that whole class of timing
+  // bugs; the browser runs it deterministically on the main frame.
   useEffect(() => {
     const unlisten = listen<{ bubble?: string }>('pill-animate-reveal', (e) => {
-      // Force a fresh CSS animation run: clear the class, wait two frames
-      // (one for React to commit the DOM change, one for the browser to
-      // acknowledge the style recalculation), then re-apply. Without this
-      // the keyframe is frequently skipped when the pill's webview has
-      // just been made visible from a hidden state — Tauri/OS compositor
-      // has a brief window where animation frames get swallowed.
-      setRevealing(false)
-      requestAnimationFrame(() => {
-        requestAnimationFrame(() => {
-          setRevealing(true)
-          setTimeout(() => setRevealing(false), REVEAL_POP_MS)
-        })
-      })
-
       const text = e.payload?.bubble ?? null
       if (text) {
         setBubbleText(text)
@@ -80,10 +79,16 @@ export default function StatusBar() {
         bubbleTimerRef.current = setTimeout(() => setBubbleText(null), BUBBLE_MS)
       }
 
+      // Defer one frame so the refs are attached after any pending React
+      // re-render (the bubble mounts in the same tick).
+      requestAnimationFrame(() => {
+        playRevealAnimation()
+      })
+
+      // Reset and schedule the attention wiggle.
       if (wiggleTimerRef.current) clearTimeout(wiggleTimerRef.current)
       wiggleTimerRef.current = setTimeout(() => {
-        setWiggle(true)
-        setTimeout(() => setWiggle(false), WIGGLE_DURATION_MS)
+        playWiggleAnimation()
       }, WIGGLE_AFTER_MS)
     })
     return () => {
@@ -92,6 +97,70 @@ export default function StatusBar() {
       if (wiggleTimerRef.current) clearTimeout(wiggleTimerRef.current)
     }
   }, [])
+
+  function playRevealAnimation() {
+    const outer = outerRef.current
+    const content = contentRef.current
+    const reduceMotion = prefersReducedMotion()
+
+    if (outer) {
+      if (reduceMotion) {
+        outer.animate(
+          [
+            { opacity: 0 },
+            { opacity: 1 },
+          ],
+          { duration: 240, easing: 'ease-out', fill: 'forwards' }
+        )
+      } else {
+        outer.animate(
+          [
+            { opacity: 0, transform: 'scale(0) rotate(-200deg) translateY(0)' },
+            { opacity: 1, transform: 'scale(1.55) rotate(-12deg) translateY(-10px)', offset: 0.28 },
+            {             transform: 'scale(1.18) rotate(10deg) translateY(-6px)',  offset: 0.52 },
+            {             transform: 'scale(0.92) rotate(-4deg) translateY(-2px)',  offset: 0.72 },
+            {             transform: 'scale(1.06) rotate(2deg) translateY(0)',       offset: 0.88 },
+            { opacity: 1, transform: 'scale(1) rotate(0) translateY(0)' },
+          ],
+          { duration: REVEAL_POP_MS, easing: 'cubic-bezier(0.22, 1.25, 0.36, 1)', fill: 'forwards' }
+        )
+      }
+    }
+
+    if (content && !reduceMotion) {
+      // Ember flood → cool-down to the normal collapsed dark. Keeps the
+      // same duration as the outer swoop so both end in lockstep.
+      content.animate(
+        [
+          { background: EMBER, boxShadow: EMBER_SHADOW, width: '44px' },
+          { background: EMBER, boxShadow: EMBER_SHADOW, width: '56px', offset: 0.28 },
+          { background: EMBER, boxShadow: EMBER_SHADOW, width: '44px', offset: 0.52 },
+          { background: 'rgba(120,65,45,0.75)', boxShadow: '0 2px 10px rgba(198,84,65,0.35), 0 0 0 0.5px rgba(255,255,255,0.12)', offset: 0.78 },
+          { background: PILL_COLLAPSED_BG, boxShadow: PILL_COLLAPSED_SHADOW, width: '44px' },
+        ],
+        { duration: REVEAL_POP_MS, easing: 'cubic-bezier(0.22, 1.25, 0.36, 1)', fill: 'forwards' }
+      )
+    }
+  }
+
+  function playWiggleAnimation() {
+    const outer = outerRef.current
+    if (!outer || prefersReducedMotion()) return
+
+    outer.animate(
+      [
+        { transform: 'rotate(0) translateY(0)' },
+        { transform: 'rotate(-9deg) translateY(-4px)', offset: 0.10 },
+        { transform: 'rotate(8deg) translateY(-6px)',  offset: 0.25 },
+        { transform: 'rotate(-6deg) translateY(-2px)', offset: 0.40 },
+        { transform: 'rotate(5deg) translateY(-3px)',  offset: 0.55 },
+        { transform: 'rotate(-3deg) translateY(-1px)', offset: 0.70 },
+        { transform: 'rotate(1.5deg) translateY(0)',   offset: 0.85 },
+        { transform: 'rotate(0) translateY(0)' },
+      ],
+      { duration: WIGGLE_DURATION_MS, easing: 'cubic-bezier(0.36, 0.07, 0.19, 0.97)', fill: 'none' }
+    )
+  }
 
   useEffect(() => {
     const unlisten = listen<{ level: number }>('audio-level', (e) => {
@@ -135,25 +204,17 @@ export default function StatusBar() {
     return `${String(m).padStart(2, '0')}:${String(sec).padStart(2, '0')}`
   }
 
-  const revealClass = [
-    'pill-outer',
-    revealing ? 'is-revealing' : '',
-    wiggle ? 'is-wiggling' : '',
-  ]
-    .filter(Boolean)
-    .join(' ')
-
   return (
-    <div className={revealClass}>
+    <div className="pill-outer" ref={outerRef}>
       {bubbleText && (
         <div className="pill-bubble" role="status" aria-live="polite">
           {bubbleText}
         </div>
       )}
       {appState === 'idle' ? (
-        <div key="collapsed" className="pill-collapsed" />
+        <div key="collapsed" className="pill-collapsed" ref={contentRef} />
       ) : appState === 'recording' ? (
-        <div key="recording" className="pill-wave">
+        <div key="recording" className="pill-wave" ref={contentRef}>
           <div className="rec-label">
             <span className="ember" />
             REC
@@ -162,7 +223,7 @@ export default function StatusBar() {
           <span className="pill-timer">{formatTime(elapsed)}</span>
         </div>
       ) : (
-        <div key={appState} className={`pill ${appState}`}>
+        <div key={appState} className={`pill ${appState}`} ref={contentRef}>
           {appState === 'processing'
             ? <span className="pill-spinner" />
             : <span className="pill-dot" />}

--- a/src/StatusBar.tsx
+++ b/src/StatusBar.tsx
@@ -101,65 +101,92 @@ export default function StatusBar() {
   function playRevealAnimation() {
     const outer = outerRef.current
     const content = contentRef.current
-    const reduceMotion = prefersReducedMotion()
+    if (!outer) return
 
-    if (outer) {
-      if (reduceMotion) {
-        outer.animate(
-          [
-            { opacity: 0 },
-            { opacity: 1 },
-          ],
-          { duration: 240, easing: 'ease-out', fill: 'forwards' }
-        )
-      } else {
-        outer.animate(
-          [
-            { opacity: 0, transform: 'scale(0) rotate(-200deg) translateY(0)' },
-            { opacity: 1, transform: 'scale(1.55) rotate(-12deg) translateY(-10px)', offset: 0.28 },
-            {             transform: 'scale(1.18) rotate(10deg) translateY(-6px)',  offset: 0.52 },
-            {             transform: 'scale(0.92) rotate(-4deg) translateY(-2px)',  offset: 0.72 },
-            {             transform: 'scale(1.06) rotate(2deg) translateY(0)',       offset: 0.88 },
-            { opacity: 1, transform: 'scale(1) rotate(0) translateY(0)' },
-          ],
-          { duration: REVEAL_POP_MS, easing: 'cubic-bezier(0.22, 1.25, 0.36, 1)', fill: 'forwards' }
-        )
-      }
+    // Kill any in-flight CSS or WAAPI animations on the elements we're
+    // about to touch — otherwise the pillFadeIn that fires on
+    // `.pill-collapsed` mount (or a previous reveal pass) competes with
+    // the inline styles and either wins or cancels ours out.
+    outer.getAnimations?.().forEach((a) => a.cancel())
+    content?.getAnimations?.().forEach((a) => a.cancel())
+
+    if (prefersReducedMotion()) {
+      return
     }
 
-    if (content && !reduceMotion) {
-      // Ember flood → cool-down to the normal collapsed dark. Keeps the
-      // same duration as the outer swoop so both end in lockstep.
-      content.animate(
-        [
-          { background: EMBER, boxShadow: EMBER_SHADOW, width: '44px' },
-          { background: EMBER, boxShadow: EMBER_SHADOW, width: '56px', offset: 0.28 },
-          { background: EMBER, boxShadow: EMBER_SHADOW, width: '44px', offset: 0.52 },
-          { background: 'rgba(120,65,45,0.75)', boxShadow: '0 2px 10px rgba(198,84,65,0.35), 0 0 0 0.5px rgba(255,255,255,0.12)', offset: 0.78 },
-          { background: PILL_COLLAPSED_BG, boxShadow: PILL_COLLAPSED_SHADOW, width: '44px' },
-        ],
-        { duration: REVEAL_POP_MS, easing: 'cubic-bezier(0.22, 1.25, 0.36, 1)', fill: 'forwards' }
-      )
+    // Stage the starting pose with transition disabled so the browser
+    // paints it at scale(0) first, then re-enable transition and swap to
+    // the target pose. The forced reflow between the two phases is the
+    // key — without it the browser coalesces both style writes into one
+    // paint and we never see the animation.
+    outer.style.transition = 'none'
+    outer.style.transformOrigin = 'center bottom'
+    outer.style.transform = 'scale(0) rotate(-200deg)'
+    outer.style.opacity = '0'
+
+    if (content) {
+      content.style.transition = 'none'
+      content.style.backgroundColor = EMBER
+      content.style.boxShadow = EMBER_SHADOW
     }
+
+    // Force the browser to lay out and paint the starting state before we
+    // queue the transition.
+    void outer.offsetHeight
+
+    requestAnimationFrame(() => {
+      // Stage 1 — explosive pop to an overshoot peak.
+      outer.style.transition =
+        'transform 360ms cubic-bezier(0.22, 1.5, 0.36, 1), opacity 180ms ease-out'
+      outer.style.transform = 'scale(1.55) rotate(-12deg) translateY(-10px)'
+      outer.style.opacity = '1'
+
+      // Stage 2 — settle back to rest with the colour cooling from ember
+      // to the normal dark. The delay matches stage 1 so the two stages
+      // cross seamlessly.
+      setTimeout(() => {
+        outer.style.transition = 'transform 520ms cubic-bezier(0.34, 1.56, 0.64, 1)'
+        outer.style.transform = 'scale(1) rotate(0) translateY(0)'
+
+        if (content) {
+          content.style.transition =
+            'background-color 520ms ease-out, box-shadow 520ms ease-out'
+          content.style.backgroundColor = PILL_COLLAPSED_BG
+          content.style.boxShadow = PILL_COLLAPSED_SHADOW
+        }
+      }, 380)
+
+      // Stage 3 — clear the inline overrides so future state changes
+      // (switching to pill-wave on record, etc.) pick up normal CSS.
+      setTimeout(() => {
+        outer.style.transition = ''
+        outer.style.transform = ''
+        outer.style.opacity = ''
+        outer.style.transformOrigin = ''
+        if (content) {
+          content.style.transition = ''
+          content.style.backgroundColor = ''
+          content.style.boxShadow = ''
+        }
+      }, REVEAL_POP_MS + 120)
+    })
   }
 
   function playWiggleAnimation() {
     const outer = outerRef.current
     if (!outer || prefersReducedMotion()) return
 
-    outer.animate(
-      [
-        { transform: 'rotate(0) translateY(0)' },
-        { transform: 'rotate(-9deg) translateY(-4px)', offset: 0.10 },
-        { transform: 'rotate(8deg) translateY(-6px)',  offset: 0.25 },
-        { transform: 'rotate(-6deg) translateY(-2px)', offset: 0.40 },
-        { transform: 'rotate(5deg) translateY(-3px)',  offset: 0.55 },
-        { transform: 'rotate(-3deg) translateY(-1px)', offset: 0.70 },
-        { transform: 'rotate(1.5deg) translateY(0)',   offset: 0.85 },
-        { transform: 'rotate(0) translateY(0)' },
-      ],
-      { duration: WIGGLE_DURATION_MS, easing: 'cubic-bezier(0.36, 0.07, 0.19, 0.97)', fill: 'none' }
-    )
+    // Wiggle fires 7 s after the reveal, long after the webview has been
+    // stable — CSS keyframe animations are reliable at that point. Use a
+    // class toggle with a reflow in between so the animation restarts if
+    // it was somehow already marked "used".
+    outer.classList.remove('is-wiggling')
+    void outer.offsetHeight
+    outer.classList.add('is-wiggling')
+
+    setTimeout(() => {
+      outer.classList.remove('is-wiggling')
+    }, WIGGLE_DURATION_MS + 50)
   }
 
   useEffect(() => {

--- a/src/StatusBar.tsx
+++ b/src/StatusBar.tsx
@@ -19,11 +19,13 @@ const WAVE_BARS = 14
 // Timings for the first-run reveal ceremony — shown once when the onboarding
 // Test step mounts. Bubble auto-dismisses after BUBBLE_MS or on the first
 // actual recording, whichever comes first. If the user stays idle for
-// WIGGLE_AFTER_MS, the pill does a single attention wiggle.
-const REVEAL_POP_MS = 380
-const BUBBLE_MS = 8000
-const WIGGLE_AFTER_MS = 10000
-const WIGGLE_DURATION_MS = 600
+// WIGGLE_AFTER_MS, the pill does a single attention wiggle. Wiggle comes
+// early enough that it reliably fires before most users have stopped
+// reading the onboarding copy; the bubble survives through the wiggle.
+const REVEAL_POP_MS = 780
+const BUBBLE_MS = 12000
+const WIGGLE_AFTER_MS = 7000
+const WIGGLE_DURATION_MS = 900
 
 export default function StatusBar() {
   const { t } = useTranslation()

--- a/src/StatusBar.tsx
+++ b/src/StatusBar.tsx
@@ -16,6 +16,15 @@ const LABELS: Record<AppState, string> = {
 
 const WAVE_BARS = 14
 
+// Timings for the first-run reveal ceremony — shown once when the onboarding
+// Test step mounts. Bubble auto-dismisses after BUBBLE_MS or on the first
+// actual recording, whichever comes first. If the user stays idle for
+// WIGGLE_AFTER_MS, the pill does a single attention wiggle.
+const REVEAL_POP_MS = 380
+const BUBBLE_MS = 8000
+const WIGGLE_AFTER_MS = 10000
+const WIGGLE_DURATION_MS = 600
+
 export default function StatusBar() {
   const { t } = useTranslation()
   const [appState, setAppState] = useState<AppState>('idle')
@@ -23,6 +32,13 @@ export default function StatusBar() {
   const [levels, setLevels] = useState<number[]>([])
   const startRef = useRef<number | null>(null)
   const timerRef = useRef<ReturnType<typeof setInterval> | null>(null)
+
+  // First-run reveal state
+  const [revealing, setRevealing] = useState(false)
+  const [bubbleText, setBubbleText] = useState<string | null>(null)
+  const [wiggle, setWiggle] = useState(false)
+  const bubbleTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const wiggleTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
   useEffect(() => {
     getCurrentWebviewWindow().setIgnoreCursorEvents(true).catch(() => {})
@@ -34,6 +50,36 @@ export default function StatusBar() {
       setAppState(e.payload.state)
     })
     return () => { unlisten.then((fn) => fn()) }
+  }, [])
+
+  // Reveal ceremony: fires once per onboarding completion. Payload carries
+  // the bubble text in whatever locale the main window is using, so the pill
+  // never has to own its own i18n state.
+  useEffect(() => {
+    const unlisten = listen<{ bubble?: string }>('pill-animate-reveal', (e) => {
+      setRevealing(true)
+      // Drop the revealing flag after the pop-in animation ends so the
+      // keyframe class doesn't restart on unrelated re-renders.
+      setTimeout(() => setRevealing(false), REVEAL_POP_MS)
+
+      const text = e.payload?.bubble ?? null
+      if (text) {
+        setBubbleText(text)
+        if (bubbleTimerRef.current) clearTimeout(bubbleTimerRef.current)
+        bubbleTimerRef.current = setTimeout(() => setBubbleText(null), BUBBLE_MS)
+      }
+
+      if (wiggleTimerRef.current) clearTimeout(wiggleTimerRef.current)
+      wiggleTimerRef.current = setTimeout(() => {
+        setWiggle(true)
+        setTimeout(() => setWiggle(false), WIGGLE_DURATION_MS)
+      }, WIGGLE_AFTER_MS)
+    })
+    return () => {
+      unlisten.then((fn) => fn())
+      if (bubbleTimerRef.current) clearTimeout(bubbleTimerRef.current)
+      if (wiggleTimerRef.current) clearTimeout(wiggleTimerRef.current)
+    }
   }, [])
 
   useEffect(() => {
@@ -53,6 +99,16 @@ export default function StatusBar() {
       timerRef.current = setInterval(() => {
         setElapsed(Math.floor((Date.now() - (startRef.current ?? Date.now())) / 1000))
       }, 1000)
+      // First real recording cancels the onboarding ceremony.
+      setBubbleText(null)
+      if (bubbleTimerRef.current) {
+        clearTimeout(bubbleTimerRef.current)
+        bubbleTimerRef.current = null
+      }
+      if (wiggleTimerRef.current) {
+        clearTimeout(wiggleTimerRef.current)
+        wiggleTimerRef.current = null
+      }
     } else {
       if (timerRef.current) clearInterval(timerRef.current)
       setElapsed(0)
@@ -68,8 +124,21 @@ export default function StatusBar() {
     return `${String(m).padStart(2, '0')}:${String(sec).padStart(2, '0')}`
   }
 
+  const revealClass = [
+    'pill-outer',
+    revealing ? 'is-revealing' : '',
+    wiggle ? 'is-wiggling' : '',
+  ]
+    .filter(Boolean)
+    .join(' ')
+
   return (
-    <div className="pill-outer">
+    <div className={revealClass}>
+      {bubbleText && (
+        <div className="pill-bubble" role="status" aria-live="polite">
+          {bubbleText}
+        </div>
+      )}
       {appState === 'idle' ? (
         <div key="collapsed" className="pill-collapsed" />
       ) : appState === 'recording' ? (

--- a/src/StatusBar.tsx
+++ b/src/StatusBar.tsx
@@ -20,7 +20,6 @@ const WAVE_BARS = 14
 // Test step mounts. Bubble auto-dismisses after BUBBLE_MS or on the first
 // actual recording, whichever comes first. If the user stays idle for
 // WIGGLE_AFTER_MS, the pill does a single attention wiggle.
-const REVEAL_POP_MS = 820
 const BUBBLE_MS = 12000
 const WIGGLE_AFTER_MS = 7000
 const WIGGLE_DURATION_MS = 900
@@ -63,15 +62,27 @@ export default function StatusBar() {
     return () => { unlisten.then((fn) => fn()) }
   }, [])
 
-  // Reveal ceremony: fires once per onboarding completion. We drive both
-  // the outer swoop and the child's ember-to-dark colour transition via
-  // the Web Animations API instead of CSS classes — CSS keyframes were
-  // being swallowed by the OS compositor in the first ~200 ms after the
-  // hidden webview became visible, so the user saw the pill appear with
-  // no motion. Imperative .animate() bypasses that whole class of timing
-  // bugs; the browser runs it deterministically on the main frame.
+  // Reveal ceremony: fires once per onboarding completion. Diagnostic
+  // logging included while we track down why production builds weren't
+  // showing the animation.
   useEffect(() => {
+    // eslint-disable-next-line no-console
+    console.log('[voca-pill] status bar mounted, registering pill-animate-reveal listener')
     const unlisten = listen<{ bubble?: string }>('pill-animate-reveal', (e) => {
+      // eslint-disable-next-line no-console
+      console.log('[voca-pill] pill-animate-reveal event received', e.payload)
+
+      // Diagnostic: unmistakable visible marker — if the user doesn't see
+      // this yellow tag appear in the pill window for 3 seconds, the event
+      // isn't reaching the listener at all (or the listener isn't mounted
+      // yet when the event fires).
+      const marker = document.createElement('div')
+      marker.textContent = 'EVENT OK'
+      marker.style.cssText =
+        'position:fixed;top:4px;left:4px;background:#FFD600;color:#111;padding:3px 8px;z-index:99999;font-size:10px;font-family:sans-serif;font-weight:700;border-radius:3px;pointer-events:none;'
+      document.body.appendChild(marker)
+      setTimeout(() => marker.remove(), 3000)
+
       const text = e.payload?.bubble ?? null
       if (text) {
         setBubbleText(text)
@@ -88,6 +99,8 @@ export default function StatusBar() {
       // Reset and schedule the attention wiggle.
       if (wiggleTimerRef.current) clearTimeout(wiggleTimerRef.current)
       wiggleTimerRef.current = setTimeout(() => {
+        // eslint-disable-next-line no-console
+        console.log('[voca-pill] wiggle timer fired')
         playWiggleAnimation()
       }, WIGGLE_AFTER_MS)
     })
@@ -99,77 +112,78 @@ export default function StatusBar() {
   }, [])
 
   function playRevealAnimation() {
+    // eslint-disable-next-line no-console
+    console.log('[voca-pill] playRevealAnimation fired')
     const outer = outerRef.current
     const content = contentRef.current
-    if (!outer) return
-
-    // Kill any in-flight CSS or WAAPI animations on the elements we're
-    // about to touch — otherwise the pillFadeIn that fires on
-    // `.pill-collapsed` mount (or a previous reveal pass) competes with
-    // the inline styles and either wins or cancels ours out.
-    outer.getAnimations?.().forEach((a) => a.cancel())
-    content?.getAnimations?.().forEach((a) => a.cancel())
+    // eslint-disable-next-line no-console
+    console.log('[voca-pill] refs attached — outer:', !!outer, 'content:', !!content)
+    if (!content) return
 
     if (prefersReducedMotion()) {
+      // eslint-disable-next-line no-console
+      console.log('[voca-pill] prefers-reduced-motion is on, skipping animation')
       return
     }
 
-    // Stage the starting pose with transition disabled so the browser
-    // paints it at scale(0) first, then re-enable transition and swap to
-    // the target pose. The forced reflow between the two phases is the
-    // key — without it the browser coalesces both style writes into one
-    // paint and we never see the animation.
-    outer.style.transition = 'none'
-    outer.style.transformOrigin = 'center bottom'
-    outer.style.transform = 'scale(0) rotate(-200deg)'
-    outer.style.opacity = '0'
+    // --- Diagnostic flash ------------------------------------------------
+    // Regardless of what happens with the structured animation below,
+    // briefly flip the pill's outline to hot magenta for 1.5 s. If the
+    // user doesn't see this, the event isn't reaching the listener OR the
+    // ref isn't bound to the right element — both require dev-mode
+    // debugging. If they DO see it, animations work but our staging has
+    // issues.
+    content.style.outline = '3px solid magenta'
+    content.style.outlineOffset = '6px'
+    setTimeout(() => {
+      if (content) {
+        content.style.outline = ''
+        content.style.outlineOffset = ''
+      }
+    }, 1500)
 
-    if (content) {
-      content.style.transition = 'none'
-      content.style.backgroundColor = EMBER
-      content.style.boxShadow = EMBER_SHADOW
+    // --- Simplified reveal: scale + ember glow -------------------------
+    // Earlier iterations tried outer-wrapper rotation + multi-stage
+    // transforms; something in the production webview kept discarding
+    // them. Pared down to the most basic possible transition: content
+    // snaps to a larger, ember-coloured state, then transitions back to
+    // rest. Uses getBoundingClientRect() for the reflow (more reliable
+    // than offsetHeight in some WebView2 builds).
+    content.style.transition = 'none'
+    content.style.backgroundColor = EMBER
+    content.style.boxShadow = EMBER_SHADOW
+
+    if (outer) {
+      outer.style.transition = 'none'
+      outer.style.transformOrigin = 'center bottom'
+      outer.style.transform = 'scale(0.3)'
     }
 
-    // Force the browser to lay out and paint the starting state before we
-    // queue the transition.
-    void outer.offsetHeight
+    content.getBoundingClientRect()
 
     requestAnimationFrame(() => {
-      // Stage 1 — explosive pop to an overshoot peak.
-      outer.style.transition =
-        'transform 360ms cubic-bezier(0.22, 1.5, 0.36, 1), opacity 180ms ease-out'
-      outer.style.transform = 'scale(1.55) rotate(-12deg) translateY(-10px)'
-      outer.style.opacity = '1'
+      content.style.transition =
+        'background-color 700ms ease-out, box-shadow 700ms ease-out'
+      content.style.backgroundColor = PILL_COLLAPSED_BG
+      content.style.boxShadow = PILL_COLLAPSED_SHADOW
 
-      // Stage 2 — settle back to rest with the colour cooling from ember
-      // to the normal dark. The delay matches stage 1 so the two stages
-      // cross seamlessly.
-      setTimeout(() => {
-        outer.style.transition = 'transform 520ms cubic-bezier(0.34, 1.56, 0.64, 1)'
-        outer.style.transform = 'scale(1) rotate(0) translateY(0)'
+      if (outer) {
+        outer.style.transition =
+          'transform 700ms cubic-bezier(0.34, 1.56, 0.64, 1)'
+        outer.style.transform = 'scale(1)'
+      }
+    })
 
-        if (content) {
-          content.style.transition =
-            'background-color 520ms ease-out, box-shadow 520ms ease-out'
-          content.style.backgroundColor = PILL_COLLAPSED_BG
-          content.style.boxShadow = PILL_COLLAPSED_SHADOW
-        }
-      }, 380)
-
-      // Stage 3 — clear the inline overrides so future state changes
-      // (switching to pill-wave on record, etc.) pick up normal CSS.
-      setTimeout(() => {
+    setTimeout(() => {
+      content.style.transition = ''
+      content.style.backgroundColor = ''
+      content.style.boxShadow = ''
+      if (outer) {
         outer.style.transition = ''
         outer.style.transform = ''
-        outer.style.opacity = ''
         outer.style.transformOrigin = ''
-        if (content) {
-          content.style.transition = ''
-          content.style.backgroundColor = ''
-          content.style.boxShadow = ''
-        }
-      }, REVEAL_POP_MS + 120)
-    })
+      }
+    }, 820)
   }
 
   function playWiggleAnimation() {

--- a/src/StatusBar.tsx
+++ b/src/StatusBar.tsx
@@ -52,6 +52,15 @@ export default function StatusBar() {
 
   useEffect(() => {
     getCurrentWebviewWindow().setIgnoreCursorEvents(true).catch(() => {})
+    // The pill webview shares index.html + base CSS with the main window,
+    // where scroll is the normal affordance. Here it isn't: the reveal
+    // animation's ember glow box-shadow (42 × 18 px) and scale/translate
+    // transforms push content past the 380 × 72 window briefly, which
+    // WebView2 answers with scrollbars on the right and bottom edges.
+    // Lock overflow on this webview only — the main window is unaffected
+    // because StatusBar is the single component that routes here.
+    document.documentElement.style.overflow = 'hidden'
+    document.body.style.overflow = 'hidden'
   }, [])
 
   useEffect(() => {

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -31,6 +31,9 @@
       "description": "Einmal drücken zum Starten, nochmal drücken zum Stoppen.",
       "next": "Weiter"
     },
+    "pill": {
+      "bubble": "Hi — drück jetzt deinen Shortcut und sag mal was ein."
+    },
     "useCase": {
       "title": "Womit arbeitest du?",
       "description": "VOCA merkt sich typische Begriffe aus deinem Fachbereich, damit Whisper sie gleich richtig versteht. Mehrfachauswahl ist OK. Kannst du später jederzeit anpassen.",

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -32,7 +32,7 @@
       "next": "Weiter"
     },
     "pill": {
-      "bubble": "Hi — drück jetzt deinen Shortcut und sag mal was ein."
+      "bubble": "Ich lebe jetzt hier."
     },
     "useCase": {
       "title": "Womit arbeitest du?",

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -32,7 +32,7 @@
       "next": "Weiter"
     },
     "pill": {
-      "bubble": "Ich lebe jetzt hier."
+      "bubble": "Hey, hier bin ich!"
     },
     "useCase": {
       "title": "Womit arbeitest du?",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -32,7 +32,7 @@
       "next": "Continue"
     },
     "pill": {
-      "bubble": "Hi — press your shortcut and say something."
+      "bubble": "I live here now."
     },
     "useCase": {
       "title": "What do you work on?",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -32,7 +32,7 @@
       "next": "Continue"
     },
     "pill": {
-      "bubble": "I live here now."
+      "bubble": "Hey, I'm here!"
     },
     "useCase": {
       "title": "What do you work on?",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -31,6 +31,9 @@
       "description": "Hold to record, release to stop. Double-tap quickly to toggle recording on/off.",
       "next": "Continue"
     },
+    "pill": {
+      "bubble": "Hi — press your shortcut and say something."
+    },
     "useCase": {
       "title": "What do you work on?",
       "description": "VOCA learns the typical vocabulary from your field so Whisper transcribes it correctly from the start. Multiple selections are fine. You can adjust this any time later.",

--- a/src/index.css
+++ b/src/index.css
@@ -255,12 +255,32 @@ input[type="password"]::-ms-reveal { display: none; }
   transform-origin: center bottom;
 }
 
-/* The reveal swoop and attention wiggle are driven from JS via the Web
-   Animations API (see `StatusBar.tsx`). CSS class-based keyframes used to
-   live here but were unreliable during the first ~200 ms after the hidden
-   pill webview became visible — the compositor swallowed animation frames
-   and the user saw nothing. Imperative .animate() sidesteps that class of
-   bugs entirely. */
+/* The first-meeting pop is driven via inline style transitions from
+   `StatusBar.tsx`. CSS keyframes and WAAPI both proved unreliable during
+   the first ~200 ms after the hidden pill webview became visible — the
+   compositor silently swallowed frames. Inline transitions with a forced
+   reflow between start and target states get around that.
+
+   The attention wiggle fires 7 s later, long after the webview is stable,
+   so a CSS keyframe + class toggle is safe here. */
+.pill-outer.is-wiggling {
+  animation: pillWiggle 900ms cubic-bezier(0.36, 0.07, 0.19, 0.97) 1 both;
+}
+@keyframes pillWiggle {
+  0%, 100% { transform: rotate(0) translateY(0); }
+  10%      { transform: rotate(-10deg) translateY(-4px); }
+  25%      { transform: rotate(9deg)   translateY(-6px); }
+  40%      { transform: rotate(-7deg)  translateY(-3px); }
+  55%      { transform: rotate(6deg)   translateY(-4px); }
+  70%      { transform: rotate(-4deg)  translateY(-1px); }
+  85%      { transform: rotate(2deg)   translateY(0); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .pill-outer.is-wiggling {
+    animation: none;
+  }
+}
 
 /* Speech bubble tethered above the pill. Appears with a short upward ease,
    stays visible until the user starts recording or BUBBLE_MS elapses. */

--- a/src/index.css
+++ b/src/index.css
@@ -255,28 +255,71 @@ input[type="password"]::-ms-reveal { display: none; }
   transform-origin: center bottom;
 }
 
-/* First-meeting pop: applied once when the onboarding Test step mounts.
-   Overshoot + settle so the pill introduces itself with a little energy. */
+/* First-meeting fly-in: applied once when the onboarding Test step mounts.
+   The pill swoops up from below, overshoots with a playful tilt, and settles
+   in place. The child element's background animates from the V-ember accent
+   to the resting dark as part of the same choreography — so it looks like
+   the pill is "cooling down" from a glowing arrival to its quiet home colour. */
 .pill-outer.is-revealing {
-  animation: pillRevealPop 380ms cubic-bezier(0.34, 1.56, 0.64, 1) 1 both;
+  animation: pillRevealSwoop 780ms cubic-bezier(0.22, 1.25, 0.36, 1) 1 both;
 }
-@keyframes pillRevealPop {
-  0%   { opacity: 0; transform: translateY(24px) scale(0.55); }
-  60%  { opacity: 1; transform: translateY(-3px)  scale(1.08); }
-  100% { opacity: 1; transform: translateY(0)     scale(1); }
+@keyframes pillRevealSwoop {
+  0%   { opacity: 0; transform: translateY(160px) scale(0.25) rotate(-18deg); }
+  55%  { opacity: 1; transform: translateY(-14px) scale(1.32) rotate(9deg);   }
+  78%  { opacity: 1; transform: translateY(0)     scale(0.94) rotate(-3deg);  }
+  92%  { transform: translateY(0) scale(1.03) rotate(1.5deg); }
+  100% { opacity: 1; transform: translateY(0) scale(1) rotate(0); }
 }
 
-/* Attention wiggle: fires at most once, 10s after the reveal if the user
-   hasn't started recording. Subtle tilt back and forth, then settles. */
+/* The collapsed bar (idle state at the moment of first reveal) gets its own
+   synced keyframe that floods with ember during flight and fades to the
+   standard dark after landing. Shadow flares too, so the arrival reads from
+   across the screen — not just a subtle nudge. */
+.pill-outer.is-revealing .pill-collapsed {
+  animation: pillRevealGlow 780ms cubic-bezier(0.22, 1.25, 0.36, 1) 1 both;
+}
+@keyframes pillRevealGlow {
+  0% {
+    background: var(--v-ember);
+    box-shadow: 0 0 24px 10px rgba(198,84,65,0.55), 0 0 0 0.5px rgba(255,255,255,0.12);
+  }
+  55% {
+    background: var(--v-ember);
+    box-shadow: 0 0 42px 18px rgba(198,84,65,0.6), 0 0 0 0.5px rgba(255,255,255,0.15);
+  }
+  78% {
+    background: rgba(120,65,45,0.75);
+    box-shadow: 0 2px 10px rgba(198,84,65,0.35), 0 0 0 0.5px rgba(255,255,255,0.12);
+  }
+  100% {
+    background: rgba(30,30,30,0.55);
+    box-shadow: 0 1px 4px rgba(0,0,0,0.35), 0 0 0 0.5px rgba(255,255,255,0.12);
+  }
+}
+.pill-outer.is-revealing .pill,
+.pill-outer.is-revealing .pill-wave {
+  animation: pillRevealDarkTint 780ms cubic-bezier(0.22, 1.25, 0.36, 1) 1 both;
+}
+@keyframes pillRevealDarkTint {
+  0%   { background: var(--v-ember); box-shadow: 0 0 40px 16px rgba(198,84,65,0.55), inset 0 0.5px 0 rgba(255,255,255,0.12); }
+  55%  { background: var(--v-ember); box-shadow: 0 0 48px 20px rgba(198,84,65,0.5), inset 0 0.5px 0 rgba(255,255,255,0.15); }
+  100% { background: rgba(20,19,17,0.88); box-shadow: 0 2px 8px rgba(0,0,0,0.18), 0 10px 30px rgba(0,0,0,0.3), inset 0 0.5px 0 rgba(255,255,255,0.1); }
+}
+
+/* Attention wiggle: fires ~7s after the reveal if the user hasn't started
+   recording yet. Bigger tilt, vertical bounce, visible from anywhere on
+   screen. Runs at most once per ceremony. */
 .pill-outer.is-wiggling {
-  animation: pillWiggle 600ms var(--ease) 1 both;
+  animation: pillWiggle 900ms cubic-bezier(0.36, 0.07, 0.19, 0.97) 1 both;
 }
 @keyframes pillWiggle {
-  0%, 100% { transform: rotate(0); }
-  15%      { transform: rotate(-3deg); }
-  35%      { transform: rotate(2.5deg); }
-  55%      { transform: rotate(-2deg); }
-  75%      { transform: rotate(1deg); }
+  0%, 100% { transform: rotate(0) translateY(0); }
+  10%      { transform: rotate(-9deg) translateY(-4px); }
+  25%      { transform: rotate(8deg)  translateY(-6px); }
+  40%      { transform: rotate(-6deg) translateY(-2px); }
+  55%      { transform: rotate(5deg)  translateY(-3px); }
+  70%      { transform: rotate(-3deg) translateY(-1px); }
+  85%      { transform: rotate(1.5deg) translateY(0); }
 }
 
 /* Speech bubble tethered above the pill. Appears with a short upward ease,
@@ -312,7 +355,10 @@ input[type="password"]::-ms-reveal { display: none; }
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .pill-outer.is-revealing {
+  .pill-outer.is-revealing,
+  .pill-outer.is-revealing .pill-collapsed,
+  .pill-outer.is-revealing .pill,
+  .pill-outer.is-revealing .pill-wave {
     animation: pillFadeIn var(--dur-2) ease 1 both;
   }
   .pill-outer.is-wiggling {

--- a/src/index.css
+++ b/src/index.css
@@ -255,76 +255,12 @@ input[type="password"]::-ms-reveal { display: none; }
   transform-origin: center bottom;
 }
 
-/* First-meeting materialisation: applied once when the onboarding Test step
-   mounts. The pill window is only 72 px tall, so we can't literally fly
-   from offscreen — instead the pill spawns from scale(0) at its rest
-   position, spins in with a -200° rotation, overshoots to 1.5×, and
-   settles through a couple of secondary bounces. The synchronised child
-   keyframe floods it with the V-ember colour during the spin and cools
-   to the resting dark by the end, which reads as the pill arriving hot
-   and calming down. */
-.pill-outer.is-revealing {
-  animation: pillRevealSwoop 820ms cubic-bezier(0.22, 1.25, 0.36, 1) 1 both;
-}
-@keyframes pillRevealSwoop {
-  0%   { opacity: 0; transform: scale(0)    rotate(-200deg) translateY(0); }
-  28%  { opacity: 1; transform: scale(1.55) rotate(-12deg)  translateY(-10px); }
-  52%  { transform: scale(1.18) rotate(10deg)  translateY(-6px); }
-  72%  { transform: scale(0.92) rotate(-4deg)  translateY(-2px); }
-  88%  { transform: scale(1.06) rotate(2deg)   translateY(0); }
-  100% { opacity: 1; transform: scale(1) rotate(0) translateY(0); }
-}
-
-/* The collapsed bar (idle state at the moment of first reveal) gets its own
-   synced keyframe that floods with ember during flight and fades to the
-   standard dark after landing. Shadow flares too, so the arrival reads from
-   across the screen — not just a subtle nudge. */
-.pill-outer.is-revealing .pill-collapsed {
-  animation: pillRevealGlow 820ms cubic-bezier(0.22, 1.25, 0.36, 1) 1 both;
-}
-@keyframes pillRevealGlow {
-  0% {
-    background: var(--v-ember);
-    box-shadow: 0 0 24px 10px rgba(198,84,65,0.55), 0 0 0 0.5px rgba(255,255,255,0.12);
-  }
-  55% {
-    background: var(--v-ember);
-    box-shadow: 0 0 42px 18px rgba(198,84,65,0.6), 0 0 0 0.5px rgba(255,255,255,0.15);
-  }
-  78% {
-    background: rgba(120,65,45,0.75);
-    box-shadow: 0 2px 10px rgba(198,84,65,0.35), 0 0 0 0.5px rgba(255,255,255,0.12);
-  }
-  100% {
-    background: rgba(30,30,30,0.55);
-    box-shadow: 0 1px 4px rgba(0,0,0,0.35), 0 0 0 0.5px rgba(255,255,255,0.12);
-  }
-}
-.pill-outer.is-revealing .pill,
-.pill-outer.is-revealing .pill-wave {
-  animation: pillRevealDarkTint 820ms cubic-bezier(0.22, 1.25, 0.36, 1) 1 both;
-}
-@keyframes pillRevealDarkTint {
-  0%   { background: var(--v-ember); box-shadow: 0 0 40px 16px rgba(198,84,65,0.55), inset 0 0.5px 0 rgba(255,255,255,0.12); }
-  55%  { background: var(--v-ember); box-shadow: 0 0 48px 20px rgba(198,84,65,0.5), inset 0 0.5px 0 rgba(255,255,255,0.15); }
-  100% { background: rgba(20,19,17,0.88); box-shadow: 0 2px 8px rgba(0,0,0,0.18), 0 10px 30px rgba(0,0,0,0.3), inset 0 0.5px 0 rgba(255,255,255,0.1); }
-}
-
-/* Attention wiggle: fires ~7s after the reveal if the user hasn't started
-   recording yet. Bigger tilt, vertical bounce, visible from anywhere on
-   screen. Runs at most once per ceremony. */
-.pill-outer.is-wiggling {
-  animation: pillWiggle 900ms cubic-bezier(0.36, 0.07, 0.19, 0.97) 1 both;
-}
-@keyframes pillWiggle {
-  0%, 100% { transform: rotate(0) translateY(0); }
-  10%      { transform: rotate(-9deg) translateY(-4px); }
-  25%      { transform: rotate(8deg)  translateY(-6px); }
-  40%      { transform: rotate(-6deg) translateY(-2px); }
-  55%      { transform: rotate(5deg)  translateY(-3px); }
-  70%      { transform: rotate(-3deg) translateY(-1px); }
-  85%      { transform: rotate(1.5deg) translateY(0); }
-}
+/* The reveal swoop and attention wiggle are driven from JS via the Web
+   Animations API (see `StatusBar.tsx`). CSS class-based keyframes used to
+   live here but were unreliable during the first ~200 ms after the hidden
+   pill webview became visible — the compositor swallowed animation frames
+   and the user saw nothing. Imperative .animate() sidesteps that class of
+   bugs entirely. */
 
 /* Speech bubble tethered above the pill. Appears with a short upward ease,
    stays visible until the user starts recording or BUBBLE_MS elapses. */
@@ -359,15 +295,6 @@ input[type="password"]::-ms-reveal { display: none; }
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .pill-outer.is-revealing,
-  .pill-outer.is-revealing .pill-collapsed,
-  .pill-outer.is-revealing .pill,
-  .pill-outer.is-revealing .pill-wave {
-    animation: pillFadeIn var(--dur-2) ease 1 both;
-  }
-  .pill-outer.is-wiggling {
-    animation: none;
-  }
   .pill-bubble {
     animation: none;
   }

--- a/src/index.css
+++ b/src/index.css
@@ -255,20 +255,24 @@ input[type="password"]::-ms-reveal { display: none; }
   transform-origin: center bottom;
 }
 
-/* First-meeting fly-in: applied once when the onboarding Test step mounts.
-   The pill swoops up from below, overshoots with a playful tilt, and settles
-   in place. The child element's background animates from the V-ember accent
-   to the resting dark as part of the same choreography — so it looks like
-   the pill is "cooling down" from a glowing arrival to its quiet home colour. */
+/* First-meeting materialisation: applied once when the onboarding Test step
+   mounts. The pill window is only 72 px tall, so we can't literally fly
+   from offscreen — instead the pill spawns from scale(0) at its rest
+   position, spins in with a -200° rotation, overshoots to 1.5×, and
+   settles through a couple of secondary bounces. The synchronised child
+   keyframe floods it with the V-ember colour during the spin and cools
+   to the resting dark by the end, which reads as the pill arriving hot
+   and calming down. */
 .pill-outer.is-revealing {
-  animation: pillRevealSwoop 780ms cubic-bezier(0.22, 1.25, 0.36, 1) 1 both;
+  animation: pillRevealSwoop 820ms cubic-bezier(0.22, 1.25, 0.36, 1) 1 both;
 }
 @keyframes pillRevealSwoop {
-  0%   { opacity: 0; transform: translateY(160px) scale(0.25) rotate(-18deg); }
-  55%  { opacity: 1; transform: translateY(-14px) scale(1.32) rotate(9deg);   }
-  78%  { opacity: 1; transform: translateY(0)     scale(0.94) rotate(-3deg);  }
-  92%  { transform: translateY(0) scale(1.03) rotate(1.5deg); }
-  100% { opacity: 1; transform: translateY(0) scale(1) rotate(0); }
+  0%   { opacity: 0; transform: scale(0)    rotate(-200deg) translateY(0); }
+  28%  { opacity: 1; transform: scale(1.55) rotate(-12deg)  translateY(-10px); }
+  52%  { transform: scale(1.18) rotate(10deg)  translateY(-6px); }
+  72%  { transform: scale(0.92) rotate(-4deg)  translateY(-2px); }
+  88%  { transform: scale(1.06) rotate(2deg)   translateY(0); }
+  100% { opacity: 1; transform: scale(1) rotate(0) translateY(0); }
 }
 
 /* The collapsed bar (idle state at the moment of first reveal) gets its own
@@ -276,7 +280,7 @@ input[type="password"]::-ms-reveal { display: none; }
    standard dark after landing. Shadow flares too, so the arrival reads from
    across the screen — not just a subtle nudge. */
 .pill-outer.is-revealing .pill-collapsed {
-  animation: pillRevealGlow 780ms cubic-bezier(0.22, 1.25, 0.36, 1) 1 both;
+  animation: pillRevealGlow 820ms cubic-bezier(0.22, 1.25, 0.36, 1) 1 both;
 }
 @keyframes pillRevealGlow {
   0% {
@@ -298,7 +302,7 @@ input[type="password"]::-ms-reveal { display: none; }
 }
 .pill-outer.is-revealing .pill,
 .pill-outer.is-revealing .pill-wave {
-  animation: pillRevealDarkTint 780ms cubic-bezier(0.22, 1.25, 0.36, 1) 1 both;
+  animation: pillRevealDarkTint 820ms cubic-bezier(0.22, 1.25, 0.36, 1) 1 both;
 }
 @keyframes pillRevealDarkTint {
   0%   { background: var(--v-ember); box-shadow: 0 0 40px 16px rgba(198,84,65,0.55), inset 0 0.5px 0 rgba(255,255,255,0.12); }

--- a/src/index.css
+++ b/src/index.css
@@ -247,7 +247,81 @@ input[type="password"]::-ms-reveal { display: none; }
 /* ============================================================
    Status Pill
    ============================================================ */
-.pill-outer { width: 100%; height: 100%; display: flex; align-items: flex-end; justify-content: center; padding-bottom: 16px; background: transparent; }
+.pill-outer {
+  width: 100%; height: 100%;
+  display: flex; flex-direction: column;
+  align-items: center; justify-content: flex-end;
+  padding-bottom: 16px; background: transparent;
+  transform-origin: center bottom;
+}
+
+/* First-meeting pop: applied once when the onboarding Test step mounts.
+   Overshoot + settle so the pill introduces itself with a little energy. */
+.pill-outer.is-revealing {
+  animation: pillRevealPop 380ms cubic-bezier(0.34, 1.56, 0.64, 1) 1 both;
+}
+@keyframes pillRevealPop {
+  0%   { opacity: 0; transform: translateY(24px) scale(0.55); }
+  60%  { opacity: 1; transform: translateY(-3px)  scale(1.08); }
+  100% { opacity: 1; transform: translateY(0)     scale(1); }
+}
+
+/* Attention wiggle: fires at most once, 10s after the reveal if the user
+   hasn't started recording. Subtle tilt back and forth, then settles. */
+.pill-outer.is-wiggling {
+  animation: pillWiggle 600ms var(--ease) 1 both;
+}
+@keyframes pillWiggle {
+  0%, 100% { transform: rotate(0); }
+  15%      { transform: rotate(-3deg); }
+  35%      { transform: rotate(2.5deg); }
+  55%      { transform: rotate(-2deg); }
+  75%      { transform: rotate(1deg); }
+}
+
+/* Speech bubble tethered above the pill. Appears with a short upward ease,
+   stays visible until the user starts recording or BUBBLE_MS elapses. */
+.pill-bubble {
+  position: relative;
+  margin-bottom: 12px;
+  padding: 9px 14px;
+  background: rgba(20,19,17,0.92);
+  color: #EBE8E0;
+  font-family: var(--f-ui);
+  font-size: 12.5px;
+  line-height: 1.4;
+  border-radius: 12px;
+  max-width: 280px;
+  text-align: center;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.22), 0 10px 28px rgba(0,0,0,0.3);
+  backdrop-filter: blur(12px); -webkit-backdrop-filter: blur(12px);
+  pointer-events: none;
+  animation: bubbleIn 320ms var(--ease) both;
+}
+.pill-bubble::after {
+  content: '';
+  position: absolute;
+  bottom: -5px; left: 50%;
+  width: 10px; height: 10px;
+  background: inherit;
+  transform: translateX(-50%) rotate(45deg);
+}
+@keyframes bubbleIn {
+  0%   { opacity: 0; transform: translateY(6px) scale(0.94); }
+  100% { opacity: 1; transform: translateY(0)   scale(1); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .pill-outer.is-revealing {
+    animation: pillFadeIn var(--dur-2) ease 1 both;
+  }
+  .pill-outer.is-wiggling {
+    animation: none;
+  }
+  .pill-bubble {
+    animation: none;
+  }
+}
 
 /* Collapsed idle state — minimal line like a sleeping indicator */
 .pill-collapsed {

--- a/src/pages/OnboardingPage.tsx
+++ b/src/pages/OnboardingPage.tsx
@@ -458,13 +458,18 @@ function StepTest({ onNext }: { onNext: () => void }) {
     (async () => {
       try {
         await invoke('unlock_recording')
+        // Emit the reveal event BEFORE showing the pill window. The pill
+        // webview runs even while hidden, so its listener already sets the
+        // `is-revealing` class — when `show_pill` then flips visibility, the
+        // animation plays from frame 0 and the user doesn't see a
+        // pre-animation flicker of the plain pill.
+        await emit('pill-animate-reveal', {
+          bubble: t('onboarding.pill.bubble', { defaultValue: 'Ich lebe jetzt hier.' }),
+        })
         await invoke('show_pill')
       } catch (e) {
         console.error('failed to unlock pill for test step:', e)
       }
-      emit('pill-animate-reveal', {
-        bubble: t('onboarding.pill.bubble', { defaultValue: 'Hi — drück jetzt deinen Shortcut und sag mal was ein.' }),
-      }).catch(() => {})
     })()
   }, [t])
 

--- a/src/pages/OnboardingPage.tsx
+++ b/src/pages/OnboardingPage.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { invoke } from '@tauri-apps/api/core'
-import { listen } from '@tauri-apps/api/event'
+import { emit, listen } from '@tauri-apps/api/event'
 import { open } from '@tauri-apps/plugin-shell'
 import { useShortcutCapture, sortShortcut } from '../hooks/useShortcutCapture'
 import { DEFAULT_SHORTCUT } from '../types'
@@ -428,6 +428,7 @@ function StepUseCase({ onNext }: { onNext: () => void }) {
 type TestAppState = 'idle' | 'recording' | 'processing' | 'inserting' | 'error'
 
 function StepTest({ onNext }: { onNext: () => void }) {
+  const { t } = useTranslation()
   const [appState, setAppState] = useState<TestAppState>('idle')
   const [text, setText] = useState('')
 
@@ -447,6 +448,25 @@ function StepTest({ onNext }: { onNext: () => void }) {
       unlistenResult.then((fn) => fn())
     }
   }, [])
+
+  // First-meeting ceremony: unlock the shortcut, reveal the pill, and send
+  // the localised bubble text along so the pill window doesn't need its own
+  // i18n state. Only runs once per onboarding — the effect's empty deps
+  // mean re-entering the step (e.g. via back) would re-fire, but the pill's
+  // animations are one-shot by design and StepTest is rarely revisited.
+  useEffect(() => {
+    (async () => {
+      try {
+        await invoke('unlock_recording')
+        await invoke('show_pill')
+      } catch (e) {
+        console.error('failed to unlock pill for test step:', e)
+      }
+      emit('pill-animate-reveal', {
+        bubble: t('onboarding.pill.bubble', { defaultValue: 'Hi — drück jetzt deinen Shortcut und sag mal was ein.' }),
+      }).catch(() => {})
+    })()
+  }, [t])
 
   const trimmed = text.trim()
   const wordCount = trimmed ? trimmed.split(/\s+/).filter(Boolean).length : 0

--- a/src/pages/OnboardingPage.tsx
+++ b/src/pages/OnboardingPage.tsx
@@ -458,15 +458,16 @@ function StepTest({ onNext }: { onNext: () => void }) {
     (async () => {
       try {
         await invoke('unlock_recording')
-        // Emit the reveal event BEFORE showing the pill window. The pill
-        // webview runs even while hidden, so its listener already sets the
-        // `is-revealing` class — when `show_pill` then flips visibility, the
-        // animation plays from frame 0 and the user doesn't see a
-        // pre-animation flicker of the plain pill.
-        await emit('pill-animate-reveal', {
-          bubble: t('onboarding.pill.bubble', { defaultValue: 'Ich lebe jetzt hier.' }),
-        })
         await invoke('show_pill')
+        // Give the OS compositor a beat to actually paint the now-visible
+        // pill window. Emitting the reveal event before this gap often
+        // resulted in the CSS animation running entirely inside the hidden
+        // webview, leaving the user with a silently-arrived pill. 120 ms is
+        // enough on the systems we've tested without feeling like a lag.
+        await new Promise((resolve) => setTimeout(resolve, 120))
+        await emit('pill-animate-reveal', {
+          bubble: t('onboarding.pill.bubble', { defaultValue: 'Hey, hier bin ich!' }),
+        })
       } catch (e) {
         console.error('failed to unlock pill for test step:', e)
       }


### PR DESCRIPTION
  Fixes both a correctness issue and a missed delight moment. Before this, the pill (status-bar overlay) was fully functional from the first frame, so pressing the hotkey during Welcome / Transcription /
  Shortcut / Use-case would fire off a recording the user never asked for. And the pill's first appearance was just "it's there" — wasted, given it's the app's primary visual identity. Now it stays hidden     
  until the Test step, then greets the user with a short choreographed reveal.
                                                                                                                                                                                                                 
  ## Changes                                                

  **Backend (`feat(onboarding): gate recording and hide pill until test step`):**                                                                                                                                
  - New `RecordingGate(Mutex<bool>)` managed state in `lib.rs`. At startup it's initialised from `general.onboardingCompleted` — false on fresh installs, true on every subsequent launch. When false, the
  `status-bar` window is hidden via `.hide()` immediately after positioning, so the pill never flashes on screen.                                                                                                
  - `on_press` in `shortcut/mod.rs` returns early when the gate is locked. Hotkey listener stays alive in the background (no re-registration needed when the gate opens).
  - New `unlock_recording` and `show_pill` tauri commands, both idempotent.                                                                                                                                      
  - `save_settings` intercepts the `onboardingCompleted` false → true transition and runs both implicitly — covers the skip button, the Done step, and any other completion path in one spot.                    
                                                                                                                                                                                                                 
  **Frontend (`feat(pill): reveal ceremony on test step`):**                                                                                                                                                     
  - `StepTest` mount calls `unlock_recording` + `show_pill`, then emits `pill-animate-reveal` with the localised bubble text in the payload. Keeps the pill webview i18n-free.                                   
  - `StatusBar` listens for the event and triggers three beats:                                                                                                                                                  
    - **Pop-in** (380 ms spring, `cubic-bezier(.34, 1.56, .64, 1)`, ~1.08 overshoot) applied once via `is-revealing` class                                                                                       
    - **Speech bubble** tethered above the pill, `bubbleIn` ease, auto-dismisses after 8 s or on the first recording                                                                                             
    - **Attention wiggle** (±3° tilt, 600 ms) fires once after 10 s of inactivity, cancelled if recording starts first                                                                                           
  - `prefers-reduced-motion: reduce` falls back: pop becomes the existing `pillFadeIn`, wiggle is suppressed, bubble skips the spring.                                                                           
  - `.pill-outer` reshaped to `flex-direction: column` so the bubble can sit above the pill without breaking the existing centred layout.                                                                        
  - Bubble text lives under `onboarding.pill.bubble` in DE + EN.                                                                                                                                                 
                                                                                                                                                                                                                 
  ## Test plan                                                                                                                                                                                                   
                                                                                                                                                                                                                 
  - [x] Fresh install → pill not visible on Welcome, Transcription, Shortcut, Use-case. Pressing the shortcut during those steps does nothing (no tray flicker, no recording)                                    
  - [x] Advance to the Test step → pill pops in with spring, bubble appears with the German bubble text ("Hi — drück jetzt deinen Shortcut und sag mal was ein.")
  - [x] Dictate something → bubble dismisses, wiggle does not fire                                                                                                                                               
  - [x] Stay idle on the Test step for ~10 s → subtle wiggle fires once, bubble still visible until the 8 s auto-dismiss                                                                                         
  - [x] Complete onboarding → pill stays visible; restart the app → pill is visible from frame 0 (no reveal animation on regular launches)                                                                       
  - [x] Skip onboarding from an early step via the skip button → pill becomes visible, recording works on next shortcut press                                                                                    
  - [x] System-level "Reduce motion" enabled → pop falls back to a simple fade, wiggle is skipped, bubble appears without bounce                                                                                 
                                                                                                                                                                                                                 
  Closes #40.