### PR TITLE
feat(onboarding): add language picker to the welcome step

### DIFF
--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -14,7 +14,8 @@
       "eyebrow": "willkommen bei",
       "lede": "Sprich - und dein Text erscheint dort, wo du tippst.",
       "cta": "Einrichten",
-      "meta": "dauert keine 90 sekunden"
+      "meta": "dauert keine 90 sekunden",
+      "languageLabel": "Sprache"
     },
     "transcription": {
       "eyebrow": "schritt 01 · transkription",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -14,7 +14,8 @@
       "eyebrow": "welcome to",
       "lede": "Speak - and your text appears exactly where you'd type it.",
       "cta": "Get started",
-      "meta": "takes less than 90 seconds"
+      "meta": "takes less than 90 seconds",
+      "languageLabel": "Language"
     },
     "transcription": {
       "eyebrow": "step 01 · transcription",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -14,7 +14,8 @@
       "eyebrow": "bienvenido a",
       "lede": "Habla - y tu texto aparece justo donde lo escribirías.",
       "cta": "Comenzar",
-      "meta": "menos de 90 segundos"
+      "meta": "menos de 90 segundos",
+      "languageLabel": "Idioma"
     },
     "transcription": {
       "eyebrow": "paso 01 · transcripción",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -14,7 +14,8 @@
       "eyebrow": "bienvenue sur",
       "lede": "Parle - et ton texte apparaît là où tu taperais.",
       "cta": "Démarrer",
-      "meta": "moins de 90 secondes"
+      "meta": "moins de 90 secondes",
+      "languageLabel": "Langue"
     },
     "transcription": {
       "eyebrow": "étape 01 · transcription",

--- a/src/i18n/locales/it.json
+++ b/src/i18n/locales/it.json
@@ -14,7 +14,8 @@
       "eyebrow": "benvenuto su",
       "lede": "Parla - e il tuo testo compare proprio dove lo digiteresti.",
       "cta": "Inizia",
-      "meta": "meno di 90 secondi"
+      "meta": "meno di 90 secondi",
+      "languageLabel": "Lingua"
     },
     "transcription": {
       "eyebrow": "passo 01 · trascrizione",

--- a/src/i18n/locales/pt.json
+++ b/src/i18n/locales/pt.json
@@ -14,7 +14,8 @@
       "eyebrow": "bem-vindo ao",
       "lede": "Fala - e o teu texto aparece mesmo onde escreverias.",
       "cta": "Começar",
-      "meta": "menos de 90 segundos"
+      "meta": "menos de 90 segundos",
+      "languageLabel": "Idioma"
     },
     "transcription": {
       "eyebrow": "passo 01 · transcrição",

--- a/src/index.css
+++ b/src/index.css
@@ -216,6 +216,29 @@ input[type="password"]::-ms-reveal { display: none; }
 .onb-err { font-family: var(--f-ui); font-size: 12.5px; color: var(--v-danger); padding: 8px 12px; border: 1px solid var(--v-danger); border-radius: var(--r-1); background: color-mix(in srgb, var(--v-danger) 8%, transparent); max-width: 500px; }
 .onb-reuse-hint { font-family: var(--f-ui); font-size: 12px; color: var(--v-ink-3); margin-top: 6px; max-width: 500px; line-height: 1.5; }
 
+/* Welcome-step language picker — quiet, top-right, native select */
+.onb-lang-picker { position: absolute; top: 24px; right: 32px; z-index: 2; }
+.onb-lang-picker select {
+  appearance: none;
+  -webkit-appearance: none;
+  font-family: var(--f-mono);
+  font-size: 11px;
+  letter-spacing: 0.04em;
+  color: var(--v-ink-3);
+  background: transparent;
+  border: 1px solid var(--v-line-soft);
+  border-radius: var(--r-1);
+  padding: 6px 22px 6px 10px;
+  cursor: pointer;
+  background-image: linear-gradient(45deg, transparent 50%, var(--v-ink-3) 50%), linear-gradient(135deg, var(--v-ink-3) 50%, transparent 50%);
+  background-position: calc(100% - 10px) calc(50% - 1px), calc(100% - 6px) calc(50% - 1px);
+  background-size: 4px 4px, 4px 4px;
+  background-repeat: no-repeat;
+  transition: border-color var(--dur-1) var(--ease), color var(--dur-1) var(--ease);
+}
+.onb-lang-picker select:hover { border-color: var(--v-ink-3); color: var(--v-ink); }
+.onb-lang-picker select:focus { outline: none; border-color: var(--v-ink); color: var(--v-ink); }
+
 /* ---- Keyboard display ---- */
 .kbd-display { display: inline-flex; align-items: center; gap: 6px; padding: 12px 16px; background: var(--v-bg); border: 1px solid var(--v-line); border-radius: var(--r-2); }
 .kbd-key { font-family: var(--f-mono); font-size: 12px; font-weight: 500; padding: 4px 8px; min-width: 28px; text-align: center; background: var(--v-surface); border: 1px solid var(--v-line); border-bottom-width: 2px; border-radius: var(--r-1); color: var(--v-ink); }

--- a/src/index.css
+++ b/src/index.css
@@ -238,6 +238,9 @@ input[type="password"]::-ms-reveal { display: none; }
 }
 .onb-lang-picker select:hover { border-color: var(--v-ink-3); color: var(--v-ink); }
 .onb-lang-picker select:focus { outline: none; border-color: var(--v-ink); color: var(--v-ink); }
+/* Native <option> rendering ignores most parent styles — force bg + text
+   so the dropdown list is readable in both light and dark themes. */
+.onb-lang-picker select option { background: var(--v-bg); color: var(--v-ink); }
 
 /* ---- Keyboard display ---- */
 .kbd-display { display: inline-flex; align-items: center; gap: 6px; padding: 12px 16px; background: var(--v-bg); border: 1px solid var(--v-line); border-radius: var(--r-2); }

--- a/src/pages/OnboardingPage.tsx
+++ b/src/pages/OnboardingPage.tsx
@@ -4,9 +4,18 @@ import { invoke } from '@tauri-apps/api/core'
 import { emit, listen } from '@tauri-apps/api/event'
 import { open } from '@tauri-apps/plugin-shell'
 import { useShortcutCapture, sortShortcut } from '../hooks/useShortcutCapture'
-import { DEFAULT_SHORTCUT } from '../types'
-import type { Settings } from '../types'
+import { DEFAULT_SHORTCUT, SUPPORTED_UI_LANGUAGES } from '../types'
+import type { Settings, UiLanguage } from '../types'
 import { formatShortcutKey } from '../shortcut/format'
+
+const LANGUAGE_LABELS: Record<UiLanguage, string> = {
+  de: 'Deutsch',
+  en: 'English',
+  es: 'Español',
+  fr: 'Français',
+  pt: 'Português',
+  it: 'Italiano',
+}
 
 interface Props {
   settings: Settings
@@ -73,6 +82,17 @@ export function OnboardingPage({ settings, onComplete }: Props) {
     await onComplete({ ...updated, general: { ...updated.general, onboardingCompleted: true } })
   }
 
+  // Persist a language change immediately without completing onboarding.
+  // Piggybacks on the same onComplete (= save) pipe but keeps
+  // onboardingCompleted unchanged so the flow doesn't collapse mid-step,
+  // and the appStore update causes App.tsx to call i18n.changeLanguage
+  // so the rest of the onboarding re-renders in the new language.
+  async function persistLanguage(lang: UiLanguage) {
+    const updated: Settings = { ...local, general: { ...local.general, language: lang } }
+    setLocal(updated)
+    await onComplete(updated)
+  }
+
   function next() { setStep(STEPS[Math.min(stepIndex + 1, STEPS.length - 1)] as Step) }
   function back() { setStep(STEPS[Math.max(stepIndex - 1, 0)] as Step) }
 
@@ -96,7 +116,7 @@ export function OnboardingPage({ settings, onComplete }: Props) {
         </div>
       )}
 
-      {step === 'welcome'      && <StepWelcome onNext={next} />}
+      {step === 'welcome'      && <StepWelcome settings={local} onLanguageChange={persistLanguage} onNext={next} />}
       {step === 'transcription' && <StepTranscription settings={local} onChange={setLocal} onNext={next} />}
       {step === 'shortcut'     && <StepShortcut settings={local} onChange={setLocal} onNext={next} />}
       {step === 'useCase'      && <StepUseCase onNext={next} />}
@@ -116,10 +136,27 @@ export function OnboardingPage({ settings, onComplete }: Props) {
 
 /* ── Welcome ─────────────────────────────────────────────────────────────── */
 
-function StepWelcome({ onNext }: { onNext: () => void }) {
+function StepWelcome({
+  settings, onLanguageChange, onNext,
+}: {
+  settings: Settings
+  onLanguageChange: (lang: UiLanguage) => void | Promise<void>
+  onNext: () => void
+}) {
   const { t } = useTranslation()
   return (
     <div className="onb-stage" style={{ justifyContent: 'center', alignItems: 'center' }}>
+      <div className="onb-lang-picker">
+        <select
+          aria-label={t('onboarding.welcome.languageLabel', 'Sprache')}
+          value={settings.general.language}
+          onChange={(e) => onLanguageChange(e.target.value as UiLanguage)}
+        >
+          {SUPPORTED_UI_LANGUAGES.map((lang) => (
+            <option key={lang} value={lang}>{LANGUAGE_LABELS[lang]}</option>
+          ))}
+        </select>
+      </div>
       <div className="ember-mark" />
       <div style={{ marginBottom: 36 }}>
         <WelcomeLogoMark size={132} />

--- a/src/pages/OnboardingPage.tsx
+++ b/src/pages/OnboardingPage.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react'
 import { Trans, useTranslation } from 'react-i18next'
 import { invoke } from '@tauri-apps/api/core'
 import { emit, listen } from '@tauri-apps/api/event'
+import { getCurrentWindow } from '@tauri-apps/api/window'
 import { open } from '@tauri-apps/plugin-shell'
 import { useShortcutCapture, sortShortcut } from '../hooks/useShortcutCapture'
 import { DEFAULT_SHORTCUT, SUPPORTED_UI_LANGUAGES } from '../types'
@@ -543,6 +544,15 @@ function StepTest({ onNext }: { onNext: () => void }) {
   useEffect(() => {
     (async () => {
       try {
+        // Bring the onboarding window to focus so the DOM shortcut fallback
+        // (`useShortcutFallback`) receives the key events for the first
+        // recording attempt. Without this, users whose last click landed
+        // outside VOCA — e.g. on the native OS language picker they just
+        // opened — have to click the onboarding window once before the
+        // shortcut responds. Global rdev capture works regardless, but on
+        // Windows/macOS that needs accessibility permissions which a
+        // fresh install hasn't granted yet.
+        getCurrentWindow().setFocus().catch(() => {})
         await invoke('unlock_recording')
         await invoke('show_pill')
         // Give the OS compositor a beat to actually paint the now-visible

--- a/src/pages/OnboardingPage.tsx
+++ b/src/pages/OnboardingPage.tsx
@@ -165,7 +165,7 @@ function StepWelcome({
       <h1 className="onb-title" style={{ fontSize: 88, marginBottom: 24 }}>
         <span className="v-wordmark" style={{ fontSize: 'inherit' }}>VOCA</span>
       </h1>
-      <p className="onb-lede" style={{ fontSize: 17, maxWidth: '44ch' }}>
+      <p className="onb-lede" style={{ fontSize: 17, maxWidth: '60ch' }}>
         {t('onboarding.welcome.lede', 'Sprich - und dein Text erscheint dort, wo du tippst.')}
       </p>
       <div style={{ display: 'flex', alignItems: 'center', gap: 20 }}>


### PR DESCRIPTION
  ## Summary                                                                                                                                                                                                     
  - Adds a quiet language picker in the top-right corner of the onboarding Welcome step. Complements the first-launch OS detection from PR #44 with a manual override: if auto-detection lands on the wrong
  - Picker options are driven by `SUPPORTED_UI_LANGUAGES`, so the six currently supported locales show up automatically and any future locale addition surfaces without touching this component. Labels are each 
  language's native name ("Deutsch", "English", "Español", "Français", "Português", "Italiano").                                                                                                                
  - Selection is persisted to `general.language` through the existing `onComplete` pipe via a new `persistLanguage` helper — `onboardingCompleted` stays untouched so the flow doesn't collapse mid-step. The    
  appStore update then triggers the existing `i18n.changeLanguage` effect in `App.tsx`, so the rest of the onboarding re-renders in the chosen language without an app restart.                                  
  - The choice survives the skip path: since we save immediately on picker change, closing or skipping the onboarding keeps the language set.                                                                    
  - `.onb-lang-picker` CSS keeps the dropdown quiet — transparent background, soft border, monospace labels, custom chevron so the indicator doesn't read as native OS chrome.                                   
  - Added `onboarding.welcome.languageLabel` to all six locale files for the picker's `aria-label`.                                                                                                              
                                                                                                                                                                                                                 
  ## Test plan                                                                                                                                                                                                   
  - [x] `npm run type-check`, `npm run lint`, `npm run test` green.                                                                                                                                              
  - [x] Fresh install on an OS with a locale VOCA supports (e.g. `en-US`): onboarding starts in English; changing via the picker to German re-renders the Welcome step in German immediately, no restart.
  - [x] Fresh install on an unsupported-locale OS (e.g. `ja-JP`): onboarding starts in English per the #44 fallback; picker offers all six options; selecting any changes the whole onboarding flow.             
  - [x] Change language via the picker, then click "skip" on the rail — the main app opens in the picked language (not the auto-detected default).                                                               
  - [x] Change language via the picker, complete onboarding normally — Settings → General shows the picked language as active.                                                                                   
  - [x] Re-open onboarding from Settings → "Restart onboarding" — the picker reflects the current stored language, not DE.                                                                                       
                                                                                                                                                                                                                 
  Closes #42