### PR TITLE
fix(pill): restore click-through after every show() cycle on Windows

### DIFF
--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -105,6 +105,8 @@ pub fn save_settings(
         *app.state::<crate::RecordingGate>().0.lock().unwrap() = true;
         if let Some(pill) = app.get_webview_window("status-bar") {
             let _ = pill.show();
+            // Re-assert click-through — see show_pill for why.
+            let _ = pill.set_ignore_cursor_events(true);
         }
     }
 
@@ -121,6 +123,10 @@ pub fn unlock_recording(app: tauri::AppHandle) -> Result<(), String> {
 pub fn show_pill(app: tauri::AppHandle) -> Result<(), String> {
     if let Some(pill) = app.get_webview_window("status-bar") {
         pill.show().map_err(|e| e.to_string())?;
+        // Re-assert click-through after show(). Windows drops the
+        // ignore-cursor flag across a hide/show cycle, which would
+        // leave the pill blocking clicks on apps underneath.
+        let _ = pill.set_ignore_cursor_events(true);
     }
     Ok(())
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -148,6 +148,13 @@ pub fn run() {
                 if let Some(m) = monitor {
                     position_status_bar(&status_bar, &m);
                 }
+                // Click-through so the pill never blocks apps underneath.
+                // The frontend also calls this on mount, but that Ignore
+                // state is not persistent on Windows — it gets dropped on
+                // every hide/show cycle. Setting it here at window-setup
+                // time closes the race where the pill is already visible
+                // before the webview JS has finished mounting.
+                let _ = status_bar.set_ignore_cursor_events(true);
                 if !onboarding_done {
                     let _ = status_bar.hide();
                 }

--- a/src/StatusBar.tsx
+++ b/src/StatusBar.tsx
@@ -51,7 +51,6 @@ export default function StatusBar() {
   const contentRef = useRef<HTMLDivElement | null>(null)
 
   useEffect(() => {
-    getCurrentWebviewWindow().setIgnoreCursorEvents(true).catch(() => {})
     // The pill webview shares index.html + base CSS with the main window,
     // where scroll is the normal affordance. Here it isn't: the reveal
     // animation's ember glow box-shadow (42 × 18 px) and scale/translate
@@ -62,6 +61,15 @@ export default function StatusBar() {
     document.documentElement.style.overflow = 'hidden'
     document.body.style.overflow = 'hidden'
   }, [])
+
+  // Re-assert click-through on every app-state change. Windows drops the
+  // ignore-cursor flag across hide/show cycles and sometimes on webview
+  // focus changes; Rust sets it at window setup and after each show(),
+  // but repeating it on every render-visible state gives us a third safety
+  // net if either of those missed. The call is idempotent and cheap.
+  useEffect(() => {
+    getCurrentWebviewWindow().setIgnoreCursorEvents(true).catch(() => {})
+  }, [appState])
 
   useEffect(() => {
     invoke<AppState>('get_app_state').then(setAppState).catch(() => {})


### PR DESCRIPTION
  ## Summary                                                                                                                                                                                                     
  The pill was blocking clicks on apps underneath it — specifically reported against Steam's "Download verwalten" button, which sits exactly where the pill is positioned. Expected behaviour is click-through:
  the pill is a passive status indicator and must never intercept input meant for whatever is running below.                                                                                                     
   
  ## Root cause                                                                                                                                                                                                  
  `setIgnoreCursorEvents(true)` was called exactly once from the React mount in `StatusBar.tsx` and the error was silently swallowed by `.catch(() => {})`. On Windows the ignore-cursor flag is **not 
  persistent** across `hide()`/`show()` cycles — the flag gets dropped each time `pill.show()` is called, which happens both on onboarding completion (`save_settings` hook) and on every Test-step unlock       
  (`show_pill` command). After any of those the pill effectively became click-blocking until the next React re-render, if any happened at all.
                                                                                                                                                                                                                 
  1. **`lib.rs` setup():** call `set_ignore_cursor_events(true)` right after positioning the status-bar window, so the flag is set before the webview JS finishes mounting. Closes the startup race where the
  pill is visible before the frontend has a chance to assert the flag.                                                                                                                                       
  2. **`commands/mod.rs`:** re-assert the flag immediately after every `pill.show()` call — both in `show_pill` and in the `save_settings` onboarding-completion branch. These are the two code paths that       
  actually cycle pill visibility.                                                                                                                                                                         
  3. **`StatusBar.tsx`:** move the Tauri API call into a `useEffect` dependent on `appState`, so the flag is re-asserted on every transition (idle ↔ recording ↔ processing ↔ inserting ↔ error). Idempotent,    
  cheap, safety net for anything either Rust call might miss.                                                                                                                                                
                                                                                                                                                                                                                 
  ## Test plan                                              
  - [x] `cargo check` + `cargo test` green on CI.                                                                                                                                                                
  - [x] `npm run type-check`, `npm run lint`, `npm run test` green (15 tests, unchanged).
  - [x] Start VOCA, open Steam → click somewhere under the pill's 380×72 footprint (e.g. "Download verwalten" button) → the click lands in Steam, not swallowed by the pill.                                     
  - [x] Trigger a recording → the pill switches to recording state, a click on the app underneath still passes through.                                                                                          
  - [x] Fresh install path: run through onboarding, reach Test step → the pill shows + accepts click-through immediately (no need to click the window first).                                                    
  - [x] Skip onboarding via the rail → pill appears, click-through works from first frame.