### PR TITLE
feat: donation surface - BMC link, About page, README with honest roadmap

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,3 @@
+# VOCA is donation-funded open source under MIT.
+# No subscriptions, no paid tier — just coffee, for those who want to chip in.
+custom: ["https://buymeacoffee.com/fnnbl"]

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 VOCA is a speech-to-text desktop app. Press a shortcut, speak, and the text lands directly in whatever you're typing into. Optional AI cleanup, custom snippets, custom dictionary, and a dictation history that stays on your device.
 
-Open source under MIT. No subscription, no paid tier, no telemetry. If it makes your life easier, you're welcome to throw a coffee in the jar — see below.
+Open source under MIT. No subscription, no paid tier, no telemetry. If it makes your life easier, you're welcome to throw a coffee in the jar - see below.
 
 ---
 
@@ -14,27 +14,27 @@ Open source under MIT. No subscription, no paid tier, no telemetry. If it makes 
 - Global push-to-talk shortcut, works system-wide
 - Six transcription providers (Groq, OpenAI, Deepgram, ElevenLabs, Gemini, Custom) plus fully local whisper.cpp in four model sizes
 - AI enhancement with five providers (Groq, Anthropic, OpenAI, Gemini, Ollama) and a custom prompt library
-- Bring-your-own-key — credentials live only in the OS keychain, never on a server
+- Bring-your-own-key - credentials live only in the OS keychain, never on a server
 - Custom dictionary for domain-specific vocabulary
 - Snippet system for boilerplate text
 - Filler-word removal (manual list, auto-detection coming)
-- Dictation history and stats — fully opt-out, local-only
+- Dictation history and stats - fully opt-out, local-only
 - Tray + floating status pill, multi-monitor aware
 - Six UI languages (DE, EN, ES, FR, PT, IT) with OS-locale auto-detection
 - Privacy-by-default: every tracking feature ships off
 
 ## Roadmap
 
-**v0.3.0 — Windows Public Beta** *(current)*
+**v0.3.0 - Windows Public Beta** *(current)*
 First publicly distributed release. Ships unsigned with documented SmartScreen bypass; Windows code signing is a later phase once donation volume can sustain the cost.
 
-**v0.4.0 — macOS Release** *(next)*
+**v0.4.0 - macOS Release** *(next)*
 Not yet shipped. Depends on Apple Developer Program membership + notarisation infrastructure; no fixed date. Targeted once the Windows beta has stabilised.
 
-**Linux — open, driven by demand**
-Not part of the current release plan, but the foundation is already there: audio, clipboard, whisper.cpp, global shortcut (X11), and Tauri bundling all work on Linux today. The remaining pieces — target-app tracking, per-app audio ducking, and the trade-offs between X11 and Wayland — are scoped, not prioritised. If interest shows up (issues, discussions, BMC messages), it moves up the list.
+**Linux - open, driven by demand**
+Not part of the current release plan, but the foundation is already there: audio, clipboard, whisper.cpp, global shortcut (X11), and Tauri bundling all work on Linux today. The remaining pieces - target-app tracking, per-app audio ducking, and the trade-offs between X11 and Wayland - are scoped, not prioritised. If interest shows up (issues, discussions, BMC messages), it moves up the list.
 
-Other platforms (iOS, Android) are out of scope — VOCA's architecture depends on a global shortcut + system text injection, which mobile operating systems don't expose to third-party apps.
+Other platforms (iOS, Android) are out of scope - VOCA's architecture depends on a global shortcut + system text injection, which mobile operating systems don't expose to third-party apps.
 
 ## Build from source
 
@@ -63,7 +63,7 @@ VOCA stays free. If you'd like to chip in, the only channel is Buy Me a Coffee:
 
 **[buymeacoffee.com/fnnbl](https://buymeacoffee.com/fnnbl)**
 
-Donations cover real costs — Apple Developer Program, Windows code signing — and help keep the project off any subscription model. Anything beyond that is bonus.
+Donations cover real costs - Apple Developer Program, Windows code signing - and help keep the project off any subscription model. Anything beyond that is bonus.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 **Running on coffee and conviction.**
 *Trying to prove you can still build great software without turning it into a monthly bill.*
 
-VOCA is a cross-platform speech-to-text desktop app. Press a shortcut, speak, and the text lands directly in whatever you're typing into. Optional AI cleanup, custom snippets, custom dictionary, and a dictation history that stays on your device.
+VOCA is a speech-to-text desktop app. Press a shortcut, speak, and the text lands directly in whatever you're typing into. Optional AI cleanup, custom snippets, custom dictionary, and a dictation history that stays on your device.
 
 Open source under MIT. No subscription, no paid tier, no telemetry. If it makes your life easier, you're welcome to throw a coffee in the jar — see below.
 
@@ -23,13 +23,18 @@ Open source under MIT. No subscription, no paid tier, no telemetry. If it makes 
 - Six UI languages (DE, EN, ES, FR, PT, IT) with OS-locale auto-detection
 - Privacy-by-default: every tracking feature ships off
 
-## Platforms
+## Roadmap
 
-Windows and macOS. Linux is not a target — VOCA is a desktop dictation tool for the platforms most knowledge workers use.
+**v0.3.0 — Windows Public Beta** *(current)*
+First publicly distributed release. Ships unsigned with documented SmartScreen bypass; Windows code signing is a later phase once donation volume can sustain the cost.
 
-## Status
+**v0.4.0 — macOS Release** *(next)*
+Not yet shipped. Depends on Apple Developer Program membership + notarisation infrastructure; no fixed date. Targeted once the Windows beta has stabilised.
 
-v0.3.0 (Windows Public Beta) is the first publicly distributed release. macOS is in active development for v0.4.0 and depends on Apple Developer ID + notarisation infrastructure.
+**Linux — open, driven by demand**
+Not part of the current release plan, but the foundation is already there: audio, clipboard, whisper.cpp, global shortcut (X11), and Tauri bundling all work on Linux today. The remaining pieces — target-app tracking, per-app audio ducking, and the trade-offs between X11 and Wayland — are scoped, not prioritised. If interest shows up (issues, discussions, BMC messages), it moves up the list.
+
+Other platforms (iOS, Android) are out of scope — VOCA's architecture depends on a global shortcut + system text injection, which mobile operating systems don't expose to third-party apps.
 
 ## Build from source
 

--- a/README.md
+++ b/README.md
@@ -1,0 +1,65 @@
+# VOCA
+
+**Running on coffee and conviction.**
+*Trying to prove you can still build great software without turning it into a monthly bill.*
+
+VOCA is a cross-platform speech-to-text desktop app. Press a shortcut, speak, and the text lands directly in whatever you're typing into. Optional AI cleanup, custom snippets, custom dictionary, and a dictation history that stays on your device.
+
+Open source under MIT. No subscription, no paid tier, no telemetry. If it makes your life easier, you're welcome to throw a coffee in the jar — see below.
+
+---
+
+## Features
+
+- Global push-to-talk shortcut, works system-wide
+- Six transcription providers (Groq, OpenAI, Deepgram, ElevenLabs, Gemini, Custom) plus fully local whisper.cpp in four model sizes
+- AI enhancement with five providers (Groq, Anthropic, OpenAI, Gemini, Ollama) and a custom prompt library
+- Bring-your-own-key — credentials live only in the OS keychain, never on a server
+- Custom dictionary for domain-specific vocabulary
+- Snippet system for boilerplate text
+- Filler-word removal (manual list, auto-detection coming)
+- Dictation history and stats — fully opt-out, local-only
+- Tray + floating status pill, multi-monitor aware
+- Six UI languages (DE, EN, ES, FR, PT, IT) with OS-locale auto-detection
+- Privacy-by-default: every tracking feature ships off
+
+## Platforms
+
+Windows and macOS. Linux is not a target — VOCA is a desktop dictation tool for the platforms most knowledge workers use.
+
+## Status
+
+v0.3.0 (Windows Public Beta) is the first publicly distributed release. macOS is in active development for v0.4.0 and depends on Apple Developer ID + notarisation infrastructure.
+
+## Build from source
+
+```bash
+# Prerequisites: Rust toolchain + Node 18+
+
+git clone https://github.com/fnnbl/voca-app.git
+cd voca-app
+npm install
+npm run tauri dev
+```
+
+Production build:
+
+```bash
+npm run tauri build
+```
+
+## Tech stack
+
+Tauri 2 (Rust + WebView), React + TypeScript on the frontend, whisper.cpp for local transcription, the OS keychain for credential storage.
+
+## Support
+
+VOCA stays free. If you'd like to chip in, the only channel is Buy Me a Coffee:
+
+**[buymeacoffee.com/fnnbl](https://buymeacoffee.com/fnnbl)**
+
+Donations cover real costs — Apple Developer Program, Windows code signing — and help keep the project off any subscription model. Anything beyond that is bonus.
+
+## License
+
+MIT. Use it, fork it, ship it. See `LICENSE` for the full text.

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -182,7 +182,12 @@
       "ai": "KI-Nachbearbeitung",
       "snippets": "Snippets",
       "dictionary": "Wörterbuch",
-      "fillers": "Füllwörter"
+      "fillers": "Füllwörter",
+      "about": "Über"
+    },
+    "about": {
+      "bmc": "Buy me a coffee",
+      "credits": "Gebaut mit Tauri, React und whisper.cpp."
     },
     "general": {
       "language": "Sprache",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -182,7 +182,12 @@
       "ai": "AI Enhancement",
       "snippets": "Snippets",
       "dictionary": "Dictionary",
-      "fillers": "Filler Words"
+      "fillers": "Filler Words",
+      "about": "About"
+    },
+    "about": {
+      "bmc": "Buy me a coffee",
+      "credits": "Built with Tauri, React, and whisper.cpp."
     },
     "general": {
       "language": "Language",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -182,7 +182,12 @@
       "ai": "Mejora con IA",
       "snippets": "Snippets",
       "dictionary": "Diccionario",
-      "fillers": "Muletillas"
+      "fillers": "Muletillas",
+      "about": "Acerca de"
+    },
+    "about": {
+      "bmc": "Buy me a coffee",
+      "credits": "Hecho con Tauri, React y whisper.cpp."
     },
     "general": {
       "language": "Idioma",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -182,7 +182,12 @@
       "ai": "Amélioration IA",
       "snippets": "Snippets",
       "dictionary": "Dictionnaire",
-      "fillers": "Mots-béquilles"
+      "fillers": "Mots-béquilles",
+      "about": "À propos"
+    },
+    "about": {
+      "bmc": "Buy me a coffee",
+      "credits": "Construit avec Tauri, React et whisper.cpp."
     },
     "general": {
       "language": "Langue",

--- a/src/i18n/locales/it.json
+++ b/src/i18n/locales/it.json
@@ -182,7 +182,12 @@
       "ai": "Miglioramento IA",
       "snippets": "Snippet",
       "dictionary": "Dizionario",
-      "fillers": "Intercalari"
+      "fillers": "Intercalari",
+      "about": "Info"
+    },
+    "about": {
+      "bmc": "Buy me a coffee",
+      "credits": "Realizzato con Tauri, React e whisper.cpp."
     },
     "general": {
       "language": "Lingua",

--- a/src/i18n/locales/pt.json
+++ b/src/i18n/locales/pt.json
@@ -182,7 +182,12 @@
       "ai": "Melhoria com IA",
       "snippets": "Snippets",
       "dictionary": "Dicionário",
-      "fillers": "Muletas"
+      "fillers": "Muletas",
+      "about": "Acerca"
+    },
+    "about": {
+      "bmc": "Buy me a coffee",
+      "credits": "Construído com Tauri, React e whisper.cpp."
     },
     "general": {
       "language": "Idioma",

--- a/src/index.css
+++ b/src/index.css
@@ -294,6 +294,14 @@ input[type="password"]::-ms-reveal { display: none; }
 .shell-nav-item svg { width: 15px; height: 15px; flex-shrink: 0; opacity: 0.75; }
 .shell-nav-item.is-active svg { opacity: 1; }
 .shell-nav-item .nav-kbd { margin-left: auto; font-family: var(--f-mono); font-size: 10px; color: var(--v-ink-4); letter-spacing: 0.05em; }
+/* Footer-anchored variant for the About item — sits at the bottom of the
+   sidebar nav, centered as a discrete pill rather than the full-width
+   button look of the function items. */
+.shell-nav-item.is-bottom { margin-top: auto; align-self: center; width: auto; padding: 7px 14px; font-size: 11.5px; color: var(--v-ink-3); letter-spacing: 0.03em; }
+.shell-nav-item.is-bottom svg { width: 13px; height: 13px; opacity: 0.7; }
+.shell-nav-item.is-bottom.is-active::before { display: none; }
+.shell-nav-item.is-bottom.is-active { background: var(--v-bg); color: var(--v-ink); font-weight: 500; }
+.shell-nav-item.is-bottom.is-active svg { opacity: 1; }
 .shell-foot { padding: 12px; display: flex; align-items: center; gap: 8px; border-top: 1px solid var(--v-line-soft); margin-top: 12px; overflow: hidden; }
 .shell-foot .status-dot { width: 7px; height: 7px; border-radius: 50%; background: var(--v-success); flex-shrink: 0; }
 .shell-foot .lbl { font-family: var(--f-mono); font-size: 10.5px; letter-spacing: 0.1em; text-transform: uppercase; color: var(--v-ink-3); flex-shrink: 0; }

--- a/src/index.css
+++ b/src/index.css
@@ -216,6 +216,34 @@ input[type="password"]::-ms-reveal { display: none; }
 .onb-err { font-family: var(--f-ui); font-size: 12.5px; color: var(--v-danger); padding: 8px 12px; border: 1px solid var(--v-danger); border-radius: var(--r-1); background: color-mix(in srgb, var(--v-danger) 8%, transparent); max-width: 500px; }
 .onb-reuse-hint { font-family: var(--f-ui); font-size: 12px; color: var(--v-ink-3); margin-top: 6px; max-width: 500px; line-height: 1.5; }
 
+/* About page */
+.about-page { max-width: 560px; margin: 0 auto; padding: 60px 0 80px; display: flex; flex-direction: column; align-items: center; text-align: center; }
+.about-brand { margin-bottom: 32px; }
+.about-wordmark { display: flex; flex-direction: column; align-items: center; gap: 12px; }
+.about-wordmark span { font-family: var(--f-display); font-weight: 800; text-transform: uppercase; font-size: 28px; letter-spacing: 0.08em; color: var(--v-ink); line-height: 1; }
+.about-headline { font-family: var(--f-display); font-weight: 800; font-size: 32px; line-height: 1.2; letter-spacing: -0.005em; color: var(--v-ink); margin: 0 0 14px; max-width: 22ch; }
+.about-statement { font-family: var(--f-ui); font-size: 14.5px; line-height: 1.55; color: var(--v-ink-2); margin: 0 0 36px; max-width: 44ch; }
+.about-divider { width: 48px; height: 1px; background: var(--v-line); margin: 8px 0 24px; }
+.about-meta { font-family: var(--f-mono); font-size: 11px; letter-spacing: 0.06em; color: var(--v-ink-3); margin: 0 0 28px; }
+.about-bmc {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  padding: 11px 22px;
+  background: var(--v-ink);
+  color: var(--v-bg);
+  border: 0;
+  border-radius: var(--r-pill);
+  font-family: var(--f-ui);
+  font-size: 14px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: transform var(--dur-1) var(--ease), background var(--dur-1) var(--ease);
+}
+.about-bmc:hover { transform: translateY(-1px); background: var(--v-ember); color: var(--v-bg); }
+.about-bmc:active { transform: translateY(0); }
+.about-credits { font-family: var(--f-ui); font-size: 12px; color: var(--v-ink-4); margin: 0; }
+
 /* Welcome-step language picker — quiet, top-right, native select */
 .onb-lang-picker { position: absolute; top: 24px; right: 32px; z-index: 2; }
 .onb-lang-picker select {

--- a/src/pages/AboutPage.tsx
+++ b/src/pages/AboutPage.tsx
@@ -1,0 +1,68 @@
+import { useTranslation } from 'react-i18next'
+import { open } from '@tauri-apps/plugin-shell'
+
+const BMC_URL = 'https://buymeacoffee.com/fnnbl'
+
+export function AboutPage() {
+  const { t } = useTranslation()
+
+  return (
+    <div className="about-page">
+      <div className="about-brand">
+        <VocaWordmark />
+      </div>
+
+      {/* The two lines below are brand copy and intentionally untranslated —
+          they're identity, not UI text. Same rationale as the VOCA wordmark
+          itself staying "VOCA" across all locales. */}
+      <h1 className="about-headline">Running on coffee and conviction.</h1>
+      <p className="about-statement">
+        Trying to prove you can still build great software without turning it
+        into a monthly bill.
+      </p>
+
+      <div className="about-divider" />
+
+      <p className="about-meta">
+        VOCA v0.3.0 · open source · MIT License
+      </p>
+
+      <button
+        type="button"
+        className="about-bmc"
+        onClick={() => open(BMC_URL).catch(() => {})}
+      >
+        <CoffeeIcon />
+        <span>{t('settings.about.bmc', 'Buy me a coffee')}</span>
+      </button>
+
+      <div className="about-divider" />
+
+      <p className="about-credits">
+        {t('settings.about.credits', 'Built with Tauri, React, and whisper.cpp.')}
+      </p>
+    </div>
+  )
+}
+
+function VocaWordmark() {
+  return (
+    <div className="about-wordmark">
+      <svg width={64} height={64} viewBox="0 0 100 100" fill="none" aria-hidden>
+        <path d="M20 24 L50 76 L80 24" stroke="var(--v-ink)" strokeWidth="11" strokeLinecap="square" strokeLinejoin="miter"/>
+        <circle cx="80" cy="24" r="8" fill="var(--v-ember)"/>
+      </svg>
+      <span>VOCA</span>
+    </div>
+  )
+}
+
+function CoffeeIcon() {
+  return (
+    <svg width={16} height={16} viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" strokeLinejoin="round" aria-hidden>
+      <path d="M2.5 6h8v4a3 3 0 0 1-3 3h-2a3 3 0 0 1-3-3V6z"/>
+      <path d="M10.5 7h1a2 2 0 0 1 0 4h-1"/>
+      <path d="M5 1.5s-1 1 0 2 0 2 0 2M7.5 1.5s-1 1 0 2 0 2 0 2"/>
+    </svg>
+  )
+}

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -9,11 +9,12 @@ import { DictionarySettings } from './settings/DictionarySettings'
 import { FillersSettings } from './settings/FillersSettings'
 import { HistoryPage } from './HistoryPage'
 import { StatsPage } from './StatsPage'
+import { AboutPage } from './AboutPage'
 import { DEFAULT_SHORTCUT } from '../types'
 import type { Settings } from '../types'
 import { formatShortcut } from '../shortcut/format'
 
-type NavId = 'history' | 'stats' | 'transcription' | 'ai' | 'snippets' | 'dictionary' | 'fillers' | 'general'
+type NavId = 'history' | 'stats' | 'transcription' | 'ai' | 'snippets' | 'dictionary' | 'fillers' | 'general' | 'about'
 
 interface Props {
   settings: Settings
@@ -72,6 +73,9 @@ export function SettingsPage({ settings, onSave }: Props) {
           <NavItem id="general" active={active} onClick={setActive} icon={<SettingsIcon />}>
             {t('settings.nav.general')}
           </NavItem>
+          <NavItem id="about" active={active} onClick={setActive} icon={<InfoIcon />}>
+            {t('settings.nav.about', 'About')}
+          </NavItem>
         </nav>
 
         <div className="shell-foot">
@@ -96,6 +100,7 @@ export function SettingsPage({ settings, onSave }: Props) {
           {active === 'dictionary'    && <DictionarySettings />}
           {active === 'fillers'       && <FillersSettings settings={settings} onChange={handleChange} />}
           {active === 'general'       && <GeneralSettings settings={settings} onChange={handleChange} />}
+          {active === 'about'         && <AboutPage />}
         </div>
       </main>
     </div>
@@ -158,4 +163,7 @@ function EraserIcon() {
 }
 function SettingsIcon() {
   return <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.25" strokeLinecap="round"><circle cx="8" cy="8" r="1.5"/><path d="M8 2v1.5M8 12.5V14M13 8h-1.5M4.5 8H3M11.5 4.5l-1 1M5.5 10.5l-1 1M11.5 11.5l-1-1M5.5 5.5l-1-1"/></svg>
+}
+function InfoIcon() {
+  return <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.25" strokeLinecap="round" strokeLinejoin="round"><circle cx="8" cy="8" r="6.25"/><path d="M8 7.25v3.5M8 5v0.25"/></svg>
 }

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -73,7 +73,7 @@ export function SettingsPage({ settings, onSave }: Props) {
           <NavItem id="general" active={active} onClick={setActive} icon={<SettingsIcon />}>
             {t('settings.nav.general')}
           </NavItem>
-          <NavItem id="about" active={active} onClick={setActive} icon={<InfoIcon />}>
+          <NavItem id="about" active={active} onClick={setActive} icon={<InfoIcon />} variant="bottom">
             {t('settings.nav.about', 'About')}
           </NavItem>
         </nav>
@@ -108,7 +108,7 @@ export function SettingsPage({ settings, onSave }: Props) {
 }
 
 function NavItem({
-  id, active, onClick, icon, kbd, children,
+  id, active, onClick, icon, kbd, children, variant,
 }: {
   id: NavId
   active: NavId
@@ -116,10 +116,12 @@ function NavItem({
   icon: ReactNode
   kbd?: string
   children: ReactNode
+  variant?: 'bottom'
 }) {
+  const variantClass = variant === 'bottom' ? ' is-bottom' : ''
   return (
     <button
-      className={`shell-nav-item${active === id ? ' is-active' : ''}`}
+      className={`shell-nav-item${active === id ? ' is-active' : ''}${variantClass}`}
       onClick={() => onClick(id)}
     >
       {icon}


### PR DESCRIPTION
  ## Summary                                                                                                                                                                                                     
  Adds the small surface for users who want to support VOCA without committing to a subscription model. Single channel (Buy Me a Coffee), surfaced consistently across the GitHub repo header, the README, and
  inside the app via a new About entry. Goes together with VOCA's brand position: free, open source, no subscription, no paid tier.                                                                              
                                                            
  ### What lands                                                                                                                                                                                                 
                                                            
  - **`.github/FUNDING.yml`** — adds the BMC URL as a `custom` link so GitHub renders the "Sponsor" button on the repo header. Deliberately *not* using GitHub Sponsors as a second channel — one route only.    
  - **New "About" sidebar entry**, anchored at the bottom of the nav as a small centered pill rather than a full-width function item. The active-state left accent line is dropped for this variant since it's an
   anchor, not a function. Backed by a new `AboutPage` component:                                                                                                                                                
    - VOCA wordmark                                         
    - Brand headline: *"Running on coffee and conviction."*                                                                                                                                                      
    - Brand statement: *"Trying to prove you can still build great software without turning it into a monthly bill."*                                                                                            
    - Version + license meta line                                                                                                                                                                                
    - Buy-me-a-coffee button (opens via Tauri `open()` in the system browser)                                                                                                                                    
    - Small credits line                                                                                                                                                                                         
  - **The two brand lines are intentionally untranslated** across all six locales — they're identity, not UI text, same rationale as keeping the wordmark "VOCA" everywhere. The nav label and credits line *are*
   translated.                                                                                                                                                                                                   
  - **`README.md` created from scratch** with the same brand statement at the top, condensed feature list, build instructions, support section pointing at BMC, and a new Roadmap section that:                  
    - states v0.3.0 (Windows) as current, ships unsigned with the SmartScreen-bypass plan                                                                                                                        
    - states v0.4.0 (macOS) as next, depending on Apple Developer Program + notarisation                                                                                                                         
    - opens the door for Linux as "driven by demand" — explains what already works (audio, clipboard, whisper.cpp, X11 shortcut, Tauri bundling) and what's still scoped (target-app, audio ducking, X11/Wayland 
    - rules out iOS/Android explicitly with the architectural reason                                                                                                                                             
  - **i18n**: `settings.nav.about` and `settings.about.{bmc,credits}` added to all six locale files.                                                                                                             
  - **Style consistency**: every em-dash in the README replaced with a plain hyphen, matching the convention from the onboarding copy rework (PR #43).                                                           
                                                                                                                                                                                                                 
  ## Test plan                                                                                                                                                                                                   
  - [x] `npm run type-check`, `npm run lint`, `npm run test` green (15 tests, unchanged).                                                                                                                        
  - [x] Open Settings → "About" (sidebar bottom, centered) → wordmark, headline, statement, version line, BMC button render correctly in light + dark theme.                                                     
  - [x] About item visually distinct from the function nav items above it: smaller, centered, no left accent line.                                                                                               
  - [x] Click the BMC button → opens `https://buymeacoffee.com/fnnbl` in the default browser.                                                                                                                    
  - [x] Switch UI language between all six locales → nav label and credits line translate; brand headline + statement stay in English.                                                                           
  - [x] Open the repo on GitHub → "Sponsor" button appears in the header and points to the BMC URL.                                                                                                              
  - [x] README renders correctly on the GitHub repo landing.                                                                                                                                                     
                                                                                                                                                                                                                 
  Closes #11