### PR TITLE
fix(pill): re-assert always-on-top alongside click-through

### DIFF
--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -105,8 +105,9 @@ pub fn save_settings(
         *app.state::<crate::RecordingGate>().0.lock().unwrap() = true;
         if let Some(pill) = app.get_webview_window("status-bar") {
             let _ = pill.show();
-            // Re-assert click-through — see show_pill for why.
+            // Re-assert click-through and topmost — see show_pill for why.
             let _ = pill.set_ignore_cursor_events(true);
+            let _ = pill.set_always_on_top(true);
         }
     }
 
@@ -127,6 +128,10 @@ pub fn show_pill(app: tauri::AppHandle) -> Result<(), String> {
         // ignore-cursor flag across a hide/show cycle, which would
         // leave the pill blocking clicks on apps underneath.
         let _ = pill.set_ignore_cursor_events(true);
+        // Same story for topmost — hide/show drops HWND_TOPMOST and the
+        // pill ends up behind any normal window (only visible on the
+        // bare desktop). Re-asserting keeps it floating above everything.
+        let _ = pill.set_always_on_top(true);
     }
     Ok(())
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -155,6 +155,12 @@ pub fn run() {
                 // time closes the race where the pill is already visible
                 // before the webview JS has finished mounting.
                 let _ = status_bar.set_ignore_cursor_events(true);
+                // Topmost is similarly non-persistent on Windows: the
+                // tauri.conf.json `alwaysOnTop` flag sets the initial
+                // HWND_TOPMOST style, but hide/show cycles can drop it,
+                // leaving the pill behind any normal window. Re-asserting
+                // here matches the click-through belt-and-suspenders.
+                let _ = status_bar.set_always_on_top(true);
                 if !onboarding_done {
                     let _ = status_bar.hide();
                 }

--- a/src/StatusBar.tsx
+++ b/src/StatusBar.tsx
@@ -62,13 +62,16 @@ export default function StatusBar() {
     document.body.style.overflow = 'hidden'
   }, [])
 
-  // Re-assert click-through on every app-state change. Windows drops the
-  // ignore-cursor flag across hide/show cycles and sometimes on webview
-  // focus changes; Rust sets it at window setup and after each show(),
-  // but repeating it on every render-visible state gives us a third safety
-  // net if either of those missed. The call is idempotent and cheap.
+  // Re-assert click-through and topmost on every app-state change.
+  // Windows drops both flags across hide/show cycles and sometimes on
+  // webview focus changes; Rust sets them at window setup and after each
+  // show(), but repeating here on every render-visible state gives us a
+  // third safety net if either of those missed. Both calls are idempotent
+  // and cheap.
   useEffect(() => {
-    getCurrentWebviewWindow().setIgnoreCursorEvents(true).catch(() => {})
+    const win = getCurrentWebviewWindow()
+    win.setIgnoreCursorEvents(true).catch(() => {})
+    win.setAlwaysOnTop(true).catch(() => {})
   }, [appState])
 
   useEffect(() => {


### PR DESCRIPTION
  Belt-and-suspenders for the pill's topmost flag, mirroring the click-through pattern from #48. The `alwaysOnTop` flag in `tauri.conf.json` only sets the initial `HWND_TOPMOST` style; on Windows hide/show
  cycles drop it, which is why the pill was visible only on the bare desktop and slipped behind VS Code, Chrome, and other normal windows.                                                                       
                                                            
  `set_always_on_top(true)` is now re-asserted in the same three places as `set_ignore_cursor_events(true)`:                                                                                                     
                                                                                                                                                                                                                 
  - `src-tauri/src/lib.rs` — at window setup                                                                                                   
  - `src-tauri/src/commands/mod.rs::save_settings` — on the onboarding-completion `show()`                                                                                                                       
  - `src-tauri/src/commands/mod.rs::show_pill` — on every `show()`                                                                                     
                                                                                                                                                                                                                 
  Plus a frontend re-assert in `StatusBar.tsx` on every `appState` change as the third safety net.                                                     
                                                                                                                                                                                                                 
  ## Test plan                                                                                                                                                                                             
  - [x] Pill is visible above VS Code during idle                                          
  - [x] Pill is visible above Chrome / fullscreen-but-windowed apps during idle                                                                                                                            
  - [x] Pill stays on top during recording, processing, inserting states                                                                               
  - [x] Click-through still works (no regressions on PR #48 behaviour)                                                                                                                                     
  - [x] First-launch onboarding reveal: pill becomes visible on top after completing the Test step