### PR TITLE
fix(audio-ducking): skip inactive sessions and match by session group

### DIFF
--- a/src-tauri/src/audio_ducking/mod.rs
+++ b/src-tauri/src/audio_ducking/mod.rs
@@ -2,27 +2,44 @@
 // restore the previous state when recording stops. Windows only for now —
 // macOS has no clean per-app mute API and is tracked separately.
 //
-// Design note: we carry plain `(PID, session-instance-ID)` pairs across
-// the mute→restore boundary, never COM objects. Each Win32 call
-// initialises its own COM context and enumerates fresh, which keeps
-// things thread-apartment-agnostic and avoids Send/Sync headaches.
+// Design note: we carry plain `(PID, session-instance-ID, session-ID)`
+// triples across the mute→restore boundary, never COM objects. Each
+// Win32 call initialises its own COM context and enumerates fresh,
+// which keeps things thread-apartment-agnostic and avoids Send/Sync
+// headaches.
 //
-// The session instance identifier (returned by
-// `IAudioSessionControl2::GetSessionInstanceIdentifier`) uniquely
-// identifies a single audio session for the lifetime of that session,
-// and stays stable even when the session toggles between active and
-// inactive (e.g. a paused video). Matching restore against the instance
-// ID first — with PID as a fallback — fixes a class of bugs where a
-// session muted during recording would get left muted because
-// PID-only matching failed to re-locate it (multi-renderer Chrome
-// is the canonical example: one Chrome.exe, many audio sessions, and
-// PID alone can't distinguish them).
+// Two identifiers are tracked because Windows audio sessions have a
+// lifecycle — Active → Inactive → Expired — and the right way to find
+// a previously-muted session at restore time depends on what stage it
+// is in:
+//
+// * `SessionInstanceIdentifier` (`IAudioSessionControl2`) uniquely
+//   identifies a single session for its lifetime. Best match when the
+//   exact session is still alive at restore time.
+//
+// * `SessionIdentifier` (also `IAudioSessionControl2`) is the
+//   group-level identifier shared by every session for the same app.
+//   Matching by group lets restore catch the case where the originally
+//   muted session expired during a long recording and Chrome (or
+//   another app) created a fresh session in the same group — fresh
+//   sessions inherit Windows' persisted per-app mute state, so without
+//   this fallback the new session comes up muted and stays muted.
+//
+// Inactive sessions are skipped at mute time entirely: there is no
+// audio currently playing through them (e.g. paused video), so there
+// is nothing to duck. Muting a paused session would only create the
+// "stuck-muted" risk above without any benefit.
 
 #[cfg(target_os = "windows")]
 #[derive(Clone, Debug)]
 pub(crate) struct MutedSession {
     pub pid: u32,
+    /// Per-instance identifier — unique to one session, best match.
     pub instance_id: String,
+    /// Group identifier — shared by every session for the same app.
+    /// Used as fallback when the original session expired and was
+    /// replaced by a fresh one in the same group.
+    pub session_id: String,
 }
 
 pub struct DuckingGuard {
@@ -82,8 +99,9 @@ mod windows_impl {
     use std::collections::HashSet;
     use windows::core::Interface;
     use windows::Win32::Media::Audio::{
-        eMultimedia, eRender, IAudioSessionControl2, IAudioSessionManager2, IMMDevice,
-        IMMDeviceEnumerator, ISimpleAudioVolume, MMDeviceEnumerator,
+        eMultimedia, eRender, AudioSessionStateActive, IAudioSessionControl2,
+        IAudioSessionManager2, IMMDevice, IMMDeviceEnumerator, ISimpleAudioVolume,
+        MMDeviceEnumerator,
     };
     use windows::Win32::System::Com::{
         CoCreateInstance, CoInitializeEx, CoTaskMemFree, CLSCTX_ALL, COINIT_MULTITHREADED,
@@ -118,6 +136,8 @@ mod windows_impl {
 
             let our_pid = std::process::id();
             let mut muted: Vec<MutedSession> = Vec::new();
+            let mut skipped_inactive = 0usize;
+            let mut skipped_already_muted = 0usize;
 
             for i in 0..count {
                 let control = match session_enum.GetSession(i) {
@@ -135,6 +155,18 @@ mod windows_impl {
                 if pid == 0 || pid == our_pid {
                     continue;
                 }
+                // Skip non-Active sessions: paused video, idle media
+                // player etc. produce no audible output, so muting them
+                // is pointless — and risks the "stuck muted" symptom
+                // when the session later expires before we restore.
+                let state = match control.GetState() {
+                    Ok(s) => s,
+                    Err(_) => continue,
+                };
+                if state != AudioSessionStateActive {
+                    skipped_inactive += 1;
+                    continue;
+                }
                 let volume = match control.cast::<ISimpleAudioVolume>() {
                     Ok(v) => v,
                     Err(_) => continue,
@@ -144,6 +176,7 @@ mod windows_impl {
                 // deliberately.
                 let was_muted = volume.GetMute().unwrap_or_default();
                 if was_muted.as_bool() {
+                    skipped_already_muted += 1;
                     continue;
                 }
                 if volume.SetMute(true, std::ptr::null()).is_err() {
@@ -153,8 +186,23 @@ mod windows_impl {
                     Ok(p) => take_pwstr(p),
                     Err(_) => String::new(),
                 };
-                muted.push(MutedSession { pid, instance_id });
+                let session_id = match control2.GetSessionIdentifier() {
+                    Ok(p) => take_pwstr(p),
+                    Err(_) => String::new(),
+                };
+                muted.push(MutedSession {
+                    pid,
+                    instance_id,
+                    session_id,
+                });
             }
+
+            log::info!(
+                "audio ducking: muted {} active session(s) (skipped {} inactive, {} already muted)",
+                muted.len(),
+                skipped_inactive,
+                skipped_already_muted
+            );
 
             Ok(muted)
         }
@@ -184,20 +232,30 @@ mod windows_impl {
                 .GetCount()
                 .map_err(|e| format!("GetCount: {e}"))?;
 
-            let tracked_ids: HashSet<&str> = sessions
+            let tracked_instances: HashSet<&str> = sessions
                 .iter()
                 .filter(|s| !s.instance_id.is_empty())
                 .map(|s| s.instance_id.as_str())
                 .collect();
-            let tracked_pids_without_id: HashSet<u32> = sessions
+            let tracked_groups: HashSet<&str> = sessions
                 .iter()
-                .filter(|s| s.instance_id.is_empty())
+                .filter(|s| !s.session_id.is_empty())
+                .map(|s| s.session_id.as_str())
+                .collect();
+            // PID-only fallback covers tracked entries from older
+            // recordings where neither identifier was captured. New
+            // entries always have at least the instance ID.
+            let tracked_pids_legacy: HashSet<u32> = sessions
+                .iter()
+                .filter(|s| s.instance_id.is_empty() && s.session_id.is_empty())
                 .map(|s| s.pid)
                 .collect();
 
-            let mut restored_ids: HashSet<String> = HashSet::new();
-            let mut restored_by_id = 0usize;
-            let mut restored_by_pid_fallback = 0usize;
+            let mut resolved_instances: HashSet<String> = HashSet::new();
+            let mut resolved_groups: HashSet<String> = HashSet::new();
+            let mut by_instance = 0usize;
+            let mut by_group = 0usize;
+            let mut by_pid_fallback = 0usize;
 
             for i in 0..count {
                 let control = match session_enum.GetSession(i) {
@@ -216,17 +274,24 @@ mod windows_impl {
                     Ok(p) => take_pwstr(p),
                     Err(_) => String::new(),
                 };
+                let session_id = match control2.GetSessionIdentifier() {
+                    Ok(p) => take_pwstr(p),
+                    Err(_) => String::new(),
+                };
 
-                // Match policy: instance ID first (uniquely identifies
-                // a single session, survives multi-session-per-PID cases
-                // like Chrome's per-renderer audio), then PID fallback
-                // for tracked entries that didn't capture an instance ID.
-                let matched_by_id = !instance_id.is_empty()
-                    && tracked_ids.contains(instance_id.as_str());
-                let matched_by_pid =
-                    !matched_by_id && tracked_pids_without_id.contains(&pid);
+                // Match priority: instance ID (precise) → group ID
+                // (catches recreations within the same app) → PID
+                // (legacy fallback only).
+                let match_instance =
+                    !instance_id.is_empty() && tracked_instances.contains(instance_id.as_str());
+                let match_group = !match_instance
+                    && !session_id.is_empty()
+                    && tracked_groups.contains(session_id.as_str());
+                let match_pid = !match_instance
+                    && !match_group
+                    && tracked_pids_legacy.contains(&pid);
 
-                if !matched_by_id && !matched_by_pid {
+                if !match_instance && !match_group && !match_pid {
                     continue;
                 }
 
@@ -234,51 +299,68 @@ mod windows_impl {
                     Ok(v) => v,
                     Err(_) => continue,
                 };
-                // Unconditional un-mute: don't trust the current GetMute
-                // state — the session may report unmuted while the
-                // mixer entry is still stuck muted (the symptom that
-                // motivated this rewrite). SetMute(false) is idempotent
-                // when the session is genuinely already unmuted.
+                // Unconditional un-mute — the per-session GetMute can
+                // report unmuted while the persisted per-app entry
+                // (which the Volume Mixer actually reflects) is still
+                // muted. SetMute(false) is idempotent when already
+                // unmuted.
                 if volume.SetMute(false, std::ptr::null()).is_ok() {
-                    if matched_by_id {
-                        restored_by_id += 1;
-                        restored_ids.insert(instance_id);
+                    if match_instance {
+                        by_instance += 1;
+                        resolved_instances.insert(instance_id.clone());
+                    } else if match_group {
+                        by_group += 1;
                     } else {
-                        restored_by_pid_fallback += 1;
+                        by_pid_fallback += 1;
+                    }
+                    if !session_id.is_empty() {
+                        // Whether matched by instance, group, or PID,
+                        // un-muting any session updates the persisted
+                        // state for the whole group — record the group
+                        // as resolved so other tracked sessions in the
+                        // same group don't show up as unaccounted.
+                        resolved_groups.insert(session_id);
                     }
                 }
             }
 
-            // Sessions we tracked but didn't find on restore. Most likely
-            // the session was destroyed before recording ended (renderer
-            // process gone, tab closed, audio engine restarted) — in
-            // which case the mute went with it and there's nothing for
-            // us to un-mute. Log if it happens so a future regression
-            // is visible.
-            let unaccounted_ids: Vec<&str> = sessions
+            // A tracked session is considered handled if either its
+            // own instance was un-muted or any session in its group
+            // was un-muted (which clears the persisted per-app mute).
+            let unaccounted = sessions
                 .iter()
-                .filter(|s| !s.instance_id.is_empty() && !restored_ids.contains(&s.instance_id))
-                .map(|s| s.instance_id.as_str())
-                .collect();
-            if !unaccounted_ids.is_empty() {
+                .filter(|s| {
+                    let inst_handled =
+                        !s.instance_id.is_empty() && resolved_instances.contains(&s.instance_id);
+                    let group_handled =
+                        !s.session_id.is_empty() && resolved_groups.contains(&s.session_id);
+                    !inst_handled && !group_handled
+                })
+                .count();
+
+            if unaccounted > 0 {
                 log::info!(
-                    "audio ducking: {} tracked session(s) not found on restore",
-                    unaccounted_ids.len()
+                    "audio ducking: {} of {} tracked session(s) not found on restore — \
+                     likely all sessions in the group expired before recording ended",
+                    unaccounted,
+                    sessions.len()
                 );
             }
-            log::debug!(
-                "audio ducking: restored {} by instance ID, {} via PID fallback",
-                restored_by_id,
-                restored_by_pid_fallback
+            log::info!(
+                "audio ducking: restored {} by instance, {} by group, {} via PID fallback",
+                by_instance,
+                by_group,
+                by_pid_fallback
             );
 
             Ok(())
         }
     }
 
-    /// Copy a COM-allocated wide string into a Rust String and free the
-    /// underlying allocation. `GetSessionInstanceIdentifier` returns an
-    /// LPWSTR the caller is responsible for releasing via CoTaskMemFree.
+    /// Copy a COM-allocated wide string into a Rust String and free
+    /// the underlying allocation. `GetSessionInstanceIdentifier` and
+    /// `GetSessionIdentifier` both return LPWSTRs the caller is
+    /// responsible for releasing via CoTaskMemFree.
     unsafe fn take_pwstr(p: windows::core::PWSTR) -> String {
         if p.0.is_null() {
             return String::new();


### PR DESCRIPTION
  PR #54 still left Chrome stuck-muted after longer recordings when the video   
  had been paused before recording. Two compounding causes:
                                                                                
  1. We were muting paused sessions (state = `Inactive`). They produce no       
  audible output anyway, so muting them does nothing useful — but inactive
  sessions can transition to `Expired` during a long recording and disappear    
  from the audio session enumerator entirely. By the time restore runs there's
  nothing left to un-mute, and a fresh session created later inherits Windows'
  persisted per-app mute state, so the new session comes up muted and stays
  muted.

  2. We only matched on the per-session instance ID. When the original session  
  expired and Chrome created a fresh one in the same app group, the new session
  had a different instance ID and no fallback could find it.                    
                                                                              
  Two corresponding fixes:

  - **Skip non-Active sessions at mute time.** `IAudioSessionControl::GetState` 
  is checked and only `AudioSessionStateActive` sessions get muted. Paused/idle
  sessions are left alone.                                                      
                                                                              
  - **Track `SessionIdentifier` (group-level) alongside the existing            
  `SessionInstanceIdentifier`.** Restore matching is now: instance ID first
  (precise) → group ID (catches recreations within the same app — un-muting any 
  session in the group clears the persisted per-app mute state) → PID (legacy 
  fallback only).

  Also bumps the restore-side log to info level and adds a mute-side summary    
  line (`muted N, skipped M inactive, K already muted`) so the exact behaviour
  is visible without a debugger when reproducing.                               
                                                                              
  **Residual edge case left intentionally:** if every session in a group expires
   before recording ends and the app hasn't created any new ones by restore
  time, we have nothing to un-mute and the persisted state stays muted. The     
  proper fix is `IAudioSessionEvents` subscription on each muted session so we
  boundary" design and is deferred until this rewrite proves insufficient.
                                                                          
  ## Test plan
  - [x] Spotify playing → start recording → stop → Spotify still playing        
  (unchanged behaviour)                                                 
  - [x] Chrome video paused **before** recording → start a long VOCA recording  
  (90+ s) → stop recording → resume video → Chrome plays normally (the main fix)
  - [x] Chrome video playing → start recording → pause video mid-recording →    
  wait 90+ s → stop recording → resume video → Chrome plays normally (group   
  fallback)                                                                     
  - [x] Chrome video playing → start recording → close tab mid-recording → stop
  recording → no error, info log mentions session not found                     
  - [x] User has manually muted Chrome via Volume Mixer before recording →      
  recording leaves it muted                                               
  - [x] Logs (`info` level) show `muted N active session(s) (skipped M inactive,
   K already muted)` and `restored X by instance, Y by group, Z via PID       
  fallback`