### PR TITLE
chore(ci): add Windows build workflow producing unsigned MSI + NSIS

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,58 @@
+name: Release Build
+
+on:
+  push:
+    branches:
+      - develop
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  windows:
+    name: Build Windows installer (unsigned)
+    runs-on: windows-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: x86_64-pc-windows-msvc
+
+      - name: Cache Rust build artifacts
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            src-tauri/target
+          key: ${{ runner.os }}-cargo-release-${{ hashFiles('src-tauri/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-release-
+            ${{ runner.os }}-cargo-
+
+      - name: Install npm dependencies
+        run: npm ci
+
+      - name: Build Tauri app (MSI + NSIS, unsigned)
+        run: npm run tauri build -- --bundles msi,nsis
+
+      - name: Upload installer artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: voca-windows-installers
+          path: |
+            src-tauri/target/release/bundle/msi/*.msi
+            src-tauri/target/release/bundle/nsis/*.exe
+          retention-days: 90
+          if-no-files-found: error

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - develop
       - main
+  pull_request:
   workflow_dispatch:
 
 permissions:

--- a/README.md
+++ b/README.md
@@ -36,6 +36,17 @@ Not part of the current release plan, but the foundation is already there: audio
 
 Other platforms (iOS, Android) are out of scope - VOCA's architecture depends on a global shortcut + system text injection, which mobile operating systems don't expose to third-party apps.
 
+## Install
+
+The Windows installer (MSI and NSIS) ships with v0.3.0 - see the [Releases page](https://github.com/fnnbl/voca-app/releases) once the first release lands.
+
+VOCA is shipped unsigned for v0.3.0, so Windows SmartScreen will block the installer on first run with "Windows protected your PC". To proceed:
+
+1. Click **More info**
+2. Click **Run anyway**
+
+The warning appears because reputation has not built up yet for a new installer, not because anything is wrong with the file. Code signing is on the roadmap (Azure Trusted Signing, ~$120/year) once donation volume can sustain it - see [issue #12](https://github.com/fnnbl/voca-app/issues/12) for the phased plan.
+
 ## Build from source
 
 ```bash


### PR DESCRIPTION
  Implements Phase 1 of the phased code-signing rollout in #12: a Tauri release build runs on push to `develop`/`main`, on every pull request, and on `workflow_dispatch`, producing both MSI and NSIS installers
                                                                                                                                                                                                                 
  #12 stays open — Phase 2 (Windows signing via Azure Trusted Signing) and Phase 3 (macOS signing + notarisation) are still ahead.
                                                                                                                                                                                                                 
  ## Changes                                                         
                                                                                                                                                                                                                 
  - New workflow `.github/workflows/release.yml`:                    
    - Runs on `windows-latest`                                                                                                                                                                                   
    - Triggers: push to `develop` and `main`, pull requests, and `workflow_dispatch` for ad-hoc builds
    - Builds `npm run tauri build -- --bundles msi,nsis`                                                                                                                                                         
    - Uploads `*.msi` and NSIS `*.exe` as a single 90-day artifact (`voca-windows-installers`)                                                                                                                   
    - Cargo cache key matches the shape used by `ci.yml`                                                                                                                                                         
  - README gains an **Install** section documenting the SmartScreen "More info → Run anyway" bypass procedure for the unsigned installer                                                                         
                                                                                                                                                                                                                 
  ## Manual verification                                                                                                                                                                                         
                                                                                                                                                                                                                 
  The PR run produces a downloadable artifact on the Action run page. Phase 1 acceptance: the MSI / NSIS download and install on a clean Windows VM with the documented SmartScreen bypass.