### PR TITLE
chore(ci): drop MSI bundle, ship NSIS-only Windows installer

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,15 +45,13 @@ jobs:
       - name: Install npm dependencies
         run: npm ci
 
-      - name: Build Tauri app (MSI + NSIS, unsigned)
-        run: npm run tauri build -- --bundles msi,nsis
+      - name: Build Tauri app (NSIS, unsigned)
+        run: npm run tauri build -- --bundles nsis
 
-      - name: Upload installer artifacts
+      - name: Upload installer artifact
         uses: actions/upload-artifact@v4
         with:
-          name: voca-windows-installers
-          path: |
-            src-tauri/target/release/bundle/msi/*.msi
-            src-tauri/target/release/bundle/nsis/*.exe
+          name: voca-windows-installer
+          path: src-tauri/target/release/bundle/nsis/*.exe
           retention-days: 90
           if-no-files-found: error

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Other platforms (iOS, Android) are out of scope - VOCA's architecture depends on
 
 ## Install
 
-The Windows installer (MSI and NSIS) ships with v0.3.0 - see the [Releases page](https://github.com/fnnbl/voca-app/releases) once the first release lands.
+The Windows installer ships with v0.3.0 - see the [Releases page](https://github.com/fnnbl/voca-app/releases) once the first release lands.
 
 VOCA is shipped unsigned for v0.3.0, so Windows SmartScreen will block the installer on first run with "Windows protected your PC". To proceed:
 


### PR DESCRIPTION
  Tauri's `bundle.targets: "all"` default produced both MSI and NSIS, but for VOCA's audience this is dead weight. Switching to NSIS-only.                                                                       
                                                                                                                                          
  ## Why                                                                                                                                                                                                         
                                                            
  - **Audience fit:** VOCA targets individual power users (devs, writers, PMs). There is no Group Policy / SCCM / Intune deployment scenario where MSI would matter.                                             
  - **Tauri 2 recommendation:** NSIS is the path Tauri actively maintains; MSI still depends on WiX 3.x, which Microsoft is sunsetting in favour of WiX 5+ (not yet supported by Tauri).                         
  - **Consumer norm:** NSIS is what Discord, Slack, Notion, etc. ship. Smaller files (~30-40%), better default per-user install UX, no admin elevation prompt for typical installs.     
  - **Operational:** one installer means clearer download instructions, simpler README, less to explain on the future landing page.                                                                              
                                                                                                                                                                                                                 
  ## Changes                                                                                                                                                                                                     
                                                                                                                                                                                                                 
  - `release.yml`: build only NSIS (`--bundles nsis`), artifact renamed singular (`voca-windows-installer`)                                                                                                      
  - README install section drops the MSI mention; users just see "Windows installer"