### PR TITLE
chore(ci): publish draft GitHub Release on v* tag push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,8 @@ on:
     branches:
       - develop
       - main
+    tags:
+      - 'v*'
   pull_request:
   workflow_dispatch:
 
@@ -15,6 +17,8 @@ jobs:
   windows:
     name: Build Windows installer (unsigned)
     runs-on: windows-latest
+    permissions:
+      contents: write
 
     steps:
       - uses: actions/checkout@v4
@@ -55,3 +59,12 @@ jobs:
           path: src-tauri/target/release/bundle/nsis/*.exe
           retention-days: 90
           if-no-files-found: error
+
+      - name: Publish draft release
+        if: startsWith(github.ref, 'refs/tags/v')
+        uses: softprops/action-gh-release@v2
+        with:
+          files: src-tauri/target/release/bundle/nsis/*.exe
+          generate_release_notes: true
+          draft: true
+          prerelease: ${{ contains(github.ref_name, '-') }}


### PR DESCRIPTION
  Extends the Windows release build to publish a GitHub Release when a `v*` tag is pushed. The release is created as a draft with the NSIS installer attached and auto-generated notes from the commit range; the
   maintainer reviews, edits notes, and clicks Publish manually. That Publish click fires `release: published`, which the SBOM workflow already listens for and attaches CycloneDX + SPDX SBOMs as additional    
  release assets.
                                                                                                                                                                                                                 
  Implements the tag-trigger and publish portion of #13. The full #13 scope (macOS build, code signing, update manifest) stays open — those depend on #12 Phases 2/3 and #10.                                    
   
  ## Changes                                                                                                                                                                                                     
                                                                  
  - `release.yml` gains a `push: tags: ['v*']` trigger                                                                                                                                                           
  - Job permissions raised to `contents: write` so the action can create the release; workflow-level permissions stay at `read` for non-tag runs
  - `prerelease` auto-toggles when the tag name contains a hyphen (e.g. `v0.3.0-rc1` → marked as pre-release)                                                                                                    
                                                                                                                                                                                                                 
  ## Release flow once this lands                                                                                                                                                                                
                                                                                                                                                                                                                 
  1. Open PR `develop` → `main`, merge it                                                                                                                                                                        
  2. Locally: `git checkout main && git pull && git tag v0.3.0 && git push origin v0.3.0`                                                                                                                        
  3. CI builds the NSIS installer and creates a draft release on the Releases page       
  4. Review draft, edit release notes, click Publish                                                                                                                                                             
  5. Publish event triggers `sbom.yml` to attach SBOMs                                                                                                                                                           
                                                                                                                                                                                                                 
  ## Out of scope                                                                                                                                                                                                
                                                                  
  - macOS bundle (blocked on Apple Developer Program / #12 Phase 3)                                                                                                                                              
  - Code signing (blocked on Azure Trusted Signing / #12 Phase 2)                                                                                                                                                
  - Auto-update manifest emitted alongside artifacts (#10)