### PR TITLE
chore: bump version 0.1.0 -> 0.3.0 for first public release

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "voca",
-  "version": "0.1.0",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "voca",
-      "version": "0.1.0",
+      "version": "0.3.0",
       "dependencies": {
         "@tauri-apps/api": "^2.0.0",
         "@tauri-apps/plugin-shell": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "voca",
-  "version": "0.1.0",
+  "version": "0.3.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -5962,7 +5962,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "voca"
-version = "0.1.0"
+version = "0.3.0"
 dependencies = [
  "arboard",
  "base64 0.22.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "voca"
-version = "0.1.0"
+version = "0.3.0"
 description = "VOCA – Speech-to-Text Desktop App"
 authors = []
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "VOCA",
-  "version": "0.1.0",
+  "version": "0.3.0",
   "identifier": "app.voca",
   "build": {
     "frontendDist": "../dist",

--- a/src/pages/AboutPage.tsx
+++ b/src/pages/AboutPage.tsx
@@ -1,5 +1,6 @@
 import { useTranslation } from 'react-i18next'
 import { open } from '@tauri-apps/plugin-shell'
+import { version as appVersion } from '../../package.json'
 
 const BMC_URL = 'https://buymeacoffee.com/fnnbl'
 
@@ -28,7 +29,7 @@ export function AboutPage({ onOpenLegal }: Props) {
       <div className="about-divider" />
 
       <p className="about-meta">
-        VOCA v0.3.0 · open source · MIT License
+        VOCA v{appVersion} · open source · MIT License
       </p>
 
       <button

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -1,5 +1,6 @@
 import { useState, type ReactNode } from 'react'
 import { useTranslation } from 'react-i18next'
+import { version as appVersion } from '../../package.json'
 import { useAppStore } from '../stores/appStore'
 import { GeneralSettings } from './settings/GeneralSettings'
 import { TranscriptionSettings } from './settings/TranscriptionSettings'
@@ -50,7 +51,7 @@ export function SettingsPage({ settings, onSave }: Props) {
         <div className="shell-brand">
           <VocaLogoMark size={22} />
           <span className="mark">VOCA</span>
-          <span className="version">v0.3</span>
+          <span className="version">v{appVersion.split('.').slice(0, 2).join('.')}</span>
         </div>
 
         <nav className="shell-nav">

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,6 +7,7 @@
     "skipLibCheck": true,
     "moduleResolution": "bundler",
     "allowImportingTsExtensions": true,
+    "resolveJsonModule": true,
     "isolatedModules": true,
     "moduleDetection": "force",
     "noEmit": true,


### PR DESCRIPTION
  Aligns the version field across all sources of truth in preparation for tagging `v0.3.0`, and removes two hardcoded version strings in the UI that would have drifted on every future bump.                    
                                                                                                                                                                                                                 
  ## Version sources                                                       
                                                                                                                                                                                                                 
  - `package.json` — root project version (drives npm + Vite)                                                                                                                                                    
  - `package-lock.json` — root project entry kept in sync with `package.json`
  - `src-tauri/tauri.conf.json` — Tauri bundle version, becomes the installer filename and About-page string                                                                                                     
  - `src-tauri/Cargo.toml` — Rust crate version                                                                                                                                                                  
  - `src-tauri/Cargo.lock` — workspace package entry kept in sync to keep `--locked` happy                                                                                                                       
                                                                                                                                                                                                                 
  ## UI: dynamic version reading                                           
                                                                                                                                                                                                                 
  Two hardcoded version strings were silently going to drift on the next bump:                                                                                                                                   
   
  - `AboutPage.tsx`: `"VOCA v0.3.0 · open source · MIT License"` → reads `version` from `package.json`, full semver displayed                                                                                    
  - `SettingsPage.tsx`: `<span className="version">v0.3</span>` → reads `version` from `package.json`, splits to keep the major.minor abbreviation in the compact sidebar pill
                                                                                                                                                                                                                 
                                                                                                                                                                                                                 
  ## Why a single bump from 0.1.0 to 0.3.0                                                                                                                                                                       
                                                                                                                                                                                                                 
  The 0.2.x range was used in the previous repo (`fnnbl/voca`, retired). The new repo started fresh at 0.1.0 in the initial commit, but the public release versioning continues from where the project was, so
  the first public release is v0.3.0 — not v0.1.0.                                                                                                                                                               
                                                                           
  ## After this lands                                                                                                                                                                                            
                                                                                                                                                                                                                 
  Once merged, the release flow is:
                                                                                                                                                                                                                 
  1. Open PR `develop` → `main`, merge it                                  
  2. Locally: `git checkout main && git pull && git tag v0.3.0 && git push origin v0.3.0`                                                                                                                        
  3. CI builds the NSIS installer and creates a draft GitHub Release                     
  4. Review draft, edit notes, click Publish                                                                                                                                                                     
  5. SBOM workflow attaches CycloneDX + SPDX SBOMs to the release