### PR TITLE
chore(ci): generate SBOMs in release workflow and clean stale bundles

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,6 +49,10 @@ jobs:
       - name: Install npm dependencies
         run: npm ci
 
+      - name: Clean stale bundle directory
+        shell: bash
+        run: rm -rf src-tauri/target/release/bundle
+
       - name: Build Tauri app (NSIS, unsigned)
         run: npm run tauri build -- --bundles nsis
 
@@ -60,11 +64,32 @@ jobs:
           retention-days: 90
           if-no-files-found: error
 
+      - name: Install Syft
+        if: startsWith(github.ref, 'refs/tags/v')
+        shell: bash
+        run: |
+          mkdir -p "$RUNNER_TEMP/syft-bin"
+          curl -sSfL https://raw.githubusercontent.com/anchore/syft/main/install.sh \
+            | sh -s -- -b "$RUNNER_TEMP/syft-bin"
+          echo "$RUNNER_TEMP/syft-bin" >> "$GITHUB_PATH"
+
+      - name: Generate SBOMs (CycloneDX + SPDX)
+        if: startsWith(github.ref, 'refs/tags/v')
+        shell: bash
+        run: |
+          syft . \
+            --override-default-catalogers 'rust,javascript' \
+            --output cyclonedx-json=sbom.cyclonedx.json \
+            --output spdx-json=sbom.spdx.json
+
       - name: Publish draft release
         if: startsWith(github.ref, 'refs/tags/v')
         uses: softprops/action-gh-release@v2
         with:
-          files: src-tauri/target/release/bundle/nsis/*.exe
+          files: |
+            src-tauri/target/release/bundle/nsis/*.exe
+            sbom.cyclonedx.json
+            sbom.spdx.json
           generate_release_notes: true
           draft: true
           prerelease: ${{ contains(github.ref_name, '-') }}

--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -7,8 +7,6 @@ on:
     branches:
       - develop
       - main
-  release:
-    types: [published]
 
 permissions:
   contents: read
@@ -80,23 +78,3 @@ jobs:
 
       - name: Gate on high+ severity
         run: grype sbom:sbom.cyclonedx.json --fail-on high --only-fixed
-
-  release-attach:
-    name: Attach SBOMs to release
-    if: github.event_name == 'release'
-    runs-on: ubuntu-latest
-    needs: generate
-    permissions:
-      contents: write
-    steps:
-      - name: Download SBOM artifacts
-        uses: actions/download-artifact@v4
-        with:
-          name: sboms
-
-      - name: Attach SBOMs to release
-        uses: softprops/action-gh-release@v2
-        with:
-          files: |
-            sbom.cyclonedx.json
-            sbom.spdx.json


### PR DESCRIPTION
  Consolidates SBOM generation and bundle hygiene into the tag-triggered release flow, so v0.3.1 onwards ships with the full asset set attached automatically.                                                      
                                                                                                                                                                                                                    
  ## Changes
                                                                                                                                                                                                                    
  - `release.yml`: wipe `src-tauri/target/release/bundle/` before `tauri build` to prevent stale installers from cargo cache restoration leaking into the release                                                   
  - `release.yml`: install Syft and generate `sbom.cyclonedx.json` + `sbom.spdx.json` after the build (tag-only), using `--override-default-catalogers 'rust,javascript'` to match `sbom.yml`'s cataloger config
  - `sbom.yml`: drop the `release-attach` job and the `release: types: [published]` trigger; the workflow now exists solely to gate PRs and pushes on CVE findings                                                  
                                                                                                                                                                                                                    
  ## Why                                                                                                                                                                                                            
                                                                                                                                                                                                                    
  The v0.3.0 ship surfaced two structural release issues:                                                                                                                                                           
  - The `release-attach` job in `sbom.yml` never ran because the draft release was created by `GITHUB_TOKEN` and GitHub's recursion guard suppresses downstream workflows even after manual user-publish (#67).     
  - Cargo cache restoration brought a stale `voca_0.1.0_x64-setup.exe` into the bundle directory, which then got attached alongside the current installer (#65).                                               
                                                                                                                                                                                                                    
  Both were worked around manually for v0.3.0; this PR removes the manual step from the v0.3.1 cycle onwards.                                                                                                       
                                                                                                                                                                                                                    
  ## Test plan                                                                                                                                                                                                      
                                                                                                                                                                                                                    
  - [ ] Open this PR — `release.yml` and `sbom.yml` both run on push/PR; only the windows build (no SBOM steps) executes
  - [ ] After merge, push a `v0.3.1` tag → exactly one draft release with three assets (NSIS exe + two SBOMs)                                                                                                       
  - [ ] Confirm `sbom.yml` still gates CVEs on PRs and pushes to develop/main                                
                                                                                                                                                                                                                    
  closes #65                                                                                                                                                                                                        
  closes #67