### PR TITLE
chore: bump version 0.3.0 -> 0.3.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "voca",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "voca",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "dependencies": {
         "@tauri-apps/api": "^2.0.0",
         "@tauri-apps/plugin-shell": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "voca",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -5962,7 +5962,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "voca"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "arboard",
  "base64 0.22.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "voca"
-version = "0.3.0"
+version = "0.3.1"
 description = "VOCA – Speech-to-Text Desktop App"
 authors = []
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "VOCA",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "identifier": "app.voca",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
  Pre-tag version bump for v0.3.1 (polish release: deterministic pill startup position + active-monitor placement). Mirrors the pattern from PR #62.                                                                
  ## Changes                                                                                                                                                                                                        
                                                                                                                                                                                                                    
  - `package.json` — top-level `version`                                                                                                                                                                            
  - `package-lock.json` — top-level + packages."" self-entry      
  - `src-tauri/tauri.conf.json` — Tauri reads this for the NSIS installer filename
  - `src-tauri/Cargo.toml` — voca crate version                                                                                                                                                                     
  - `src-tauri/Cargo.lock` — voca crate self-entry (urlpattern@0.3.0 left untouched)                                                                                                                                
                                                                                                                                                                                                                    
  ## After merge                                                                                                                                                                                                    
                                                                                                                                                                                                                    
  1. Merge `develop` → `main`                                                                                                                                                                                       
  2. Tag `v0.3.1` on main, push tag                                                                                                                                                                                 
  3. `release.yml` builds + generates SBOMs inline + creates draft release with three assets (NSIS exe + two SBOMs) — first end-to-end run of the post-#71 pipeline
  4. Manually publish the draft on GitHub