### PR TITLE
Release v0.3.1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,6 +49,10 @@ jobs:
       - name: Install npm dependencies
         run: npm ci
 
+      - name: Clean stale bundle directory
+        shell: bash
+        run: rm -rf src-tauri/target/release/bundle
+
       - name: Build Tauri app (NSIS, unsigned)
         run: npm run tauri build -- --bundles nsis
 
@@ -60,11 +64,32 @@ jobs:
           retention-days: 90
           if-no-files-found: error
 
+      - name: Install Syft
+        if: startsWith(github.ref, 'refs/tags/v')
+        shell: bash
+        run: |
+          mkdir -p "$RUNNER_TEMP/syft-bin"
+          curl -sSfL https://raw.githubusercontent.com/anchore/syft/main/install.sh \
+            | sh -s -- -b "$RUNNER_TEMP/syft-bin"
+          echo "$RUNNER_TEMP/syft-bin" >> "$GITHUB_PATH"
+
+      - name: Generate SBOMs (CycloneDX + SPDX)
+        if: startsWith(github.ref, 'refs/tags/v')
+        shell: bash
+        run: |
+          syft . \
+            --override-default-catalogers 'rust,javascript' \
+            --output cyclonedx-json=sbom.cyclonedx.json \
+            --output spdx-json=sbom.spdx.json
+
       - name: Publish draft release
         if: startsWith(github.ref, 'refs/tags/v')
         uses: softprops/action-gh-release@v2
         with:
-          files: src-tauri/target/release/bundle/nsis/*.exe
+          files: |
+            src-tauri/target/release/bundle/nsis/*.exe
+            sbom.cyclonedx.json
+            sbom.spdx.json
           generate_release_notes: true
           draft: true
           prerelease: ${{ contains(github.ref_name, '-') }}

--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -7,8 +7,6 @@ on:
     branches:
       - develop
       - main
-  release:
-    types: [published]
 
 permissions:
   contents: read
@@ -80,23 +78,3 @@ jobs:
 
       - name: Gate on high+ severity
         run: grype sbom:sbom.cyclonedx.json --fail-on high --only-fixed
-
-  release-attach:
-    name: Attach SBOMs to release
-    if: github.event_name == 'release'
-    runs-on: ubuntu-latest
-    needs: generate
-    permissions:
-      contents: write
-    steps:
-      - name: Download SBOM artifacts
-        uses: actions/download-artifact@v4
-        with:
-          name: sboms
-
-      - name: Attach SBOMs to release
-        uses: softprops/action-gh-release@v2
-        with:
-          files: |
-            sbom.cyclonedx.json
-            sbom.spdx.json

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "voca",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "voca",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "dependencies": {
         "@tauri-apps/api": "^2.0.0",
         "@tauri-apps/plugin-shell": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "voca",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -5962,7 +5962,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "voca"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "arboard",
  "base64 0.22.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "voca"
-version = "0.3.0"
+version = "0.3.1"
 description = "VOCA – Speech-to-Text Desktop App"
 authors = []
 edition = "2021"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -33,7 +33,7 @@ reqwest = { version = "0.12", features = ["multipart", "rustls-tls", "json"], de
 arboard = "3"
 enigo = "0.2"
 whisper-rs = "0.16"
-tokio = { version = "1", features = ["fs", "rt"] }
+tokio = { version = "1", features = ["fs", "rt", "time"] }
 base64 = "0.22"
 regex = "1"
 chrono = { version = "0.4", default-features = false, features = ["clock"] }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -137,16 +137,24 @@ pub fn run() {
             *app.state::<RecordingGate>().0.lock().unwrap() = onboarding_done;
 
             if let Some(status_bar) = app.get_webview_window("status-bar") {
-                // Prefer primary_monitor for reliable startup positioning;
-                // the monitor's .position() offset is added so multi-monitor
-                // setups where the primary isn't at (0,0) work correctly.
-                let monitor = status_bar
-                    .primary_monitor()
+                // The pill window starts hidden (tauri.conf.json
+                // `visible: false`) so the OS-chosen initial position is
+                // never visible. We pick the active monitor (the one the
+                // cursor is on), position deterministically, then show.
+                let monitors = status_bar.available_monitors().unwrap_or_default();
+                let cursor_monitor = app
+                    .cursor_position()
                     .ok()
-                    .flatten()
+                    .and_then(|cursor| monitor_for_cursor(&monitors, cursor))
+                    .and_then(|idx| monitors.get(idx).cloned());
+                let initial_monitor = cursor_monitor
+                    .or_else(|| status_bar.primary_monitor().ok().flatten())
                     .or_else(|| status_bar.current_monitor().ok().flatten());
-                if let Some(m) = monitor {
-                    position_status_bar(&status_bar, &m);
+                let initial_monitor_name = initial_monitor
+                    .as_ref()
+                    .and_then(|m| m.name().cloned());
+                if let Some(m) = &initial_monitor {
+                    position_status_bar(&status_bar, m);
                 }
                 // Click-through so the pill never blocks apps underneath.
                 // The frontend also calls this on mount, but that Ignore
@@ -161,9 +169,17 @@ pub fn run() {
                 // leaving the pill behind any normal window. Re-asserting
                 // here matches the click-through belt-and-suspenders.
                 let _ = status_bar.set_always_on_top(true);
-                if !onboarding_done {
-                    let _ = status_bar.hide();
+                if onboarding_done {
+                    let _ = status_bar.show();
                 }
+
+                // Watch for active-monitor changes (cursor crossing
+                // monitor boundaries). The pill follows monitors, not
+                // pixel-level cursor movement.
+                let app_handle = app.handle().clone();
+                tauri::async_runtime::spawn(async move {
+                    watch_active_monitor(app_handle, initial_monitor_name).await;
+                });
             }
 
             if let Some(main) = app.get_webview_window("main") {
@@ -248,6 +264,48 @@ pub fn position_status_bar(window: &tauri::WebviewWindow, monitor: &tauri::Monit
     let x = origin.x + (size.width as i32 - win_w) / 2;
     let y = origin.y + size.height as i32 - win_h - (56.0 * scale) as i32;
     let _ = window.set_position(tauri::PhysicalPosition::new(x, y));
+}
+
+fn monitor_for_cursor(
+    monitors: &[tauri::Monitor],
+    cursor: tauri::PhysicalPosition<f64>,
+) -> Option<usize> {
+    monitors.iter().position(|m| {
+        let mp = m.position();
+        let ms = m.size();
+        let x = cursor.x as i32;
+        let y = cursor.y as i32;
+        x >= mp.x
+            && x < mp.x + ms.width as i32
+            && y >= mp.y
+            && y < mp.y + ms.height as i32
+    })
+}
+
+async fn watch_active_monitor(app: tauri::AppHandle, initial_monitor_name: Option<String>) {
+    use std::time::Duration;
+    let mut last_name = initial_monitor_name;
+    loop {
+        tokio::time::sleep(Duration::from_millis(200)).await;
+        let Some(status_bar) = app.get_webview_window("status-bar") else {
+            return;
+        };
+        if !status_bar.is_visible().unwrap_or(false) {
+            continue;
+        }
+        let Ok(cursor) = app.cursor_position() else { continue };
+        let monitors = match status_bar.available_monitors() {
+            Ok(m) if !m.is_empty() => m,
+            _ => continue,
+        };
+        let Some(idx) = monitor_for_cursor(&monitors, cursor) else { continue };
+        let monitor = &monitors[idx];
+        let name = monitor.name().cloned();
+        if name != last_name {
+            position_status_bar(&status_bar, monitor);
+            last_name = name;
+        }
+    }
 }
 
 pub fn update_tray_icon(app: &tauri::AppHandle, state: &AppState) {

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "VOCA",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "identifier": "app.voca",
   "build": {
     "frontendDist": "../dist",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -34,7 +34,7 @@
         "height": 72,
         "resizable": false,
         "fullscreen": false,
-        "visible": true,
+        "visible": false,
         "decorations": false,
         "shadow": false,
         "alwaysOnTop": true,


### PR DESCRIPTION
  First polish release after the public v0.3.0 beta. End-to-end validation run for the post-#71
  release pipeline (inline SBOMs + bundle cleanup).                                             
  
                                                                                                
  - **#71** `chore(ci)` SBOMs generated inline in release.yml + bundle cleanup before tauri
  build (closes #65, #67)                                                                       
  - **#72** `feat(pill)` deterministic startup position + active-monitor placement (closes #68,
  #69)                                                                                          
  - **#73** `chore` version bump 0.3.0 → 0.3.1                                                  
                                              
  ## Tag and ship after merge                                                                   
                                                                                                
  1. `git checkout main && git pull`                                                            
  2. `git tag v0.3.1 && git push origin v0.3.1`                                                 
  3. `release.yml` builds NSIS, generates both SBOMs inline, creates draft release with three
  assets                                                                                        
  4. Manually publish the draft on GitHub