### PR TITLE
feat(fillers): suggest filler words from transcript history

### DIFF
--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -333,13 +333,33 @@ pub fn save_snippets(app: tauri::AppHandle, snippets: Vec<crate::storage::Snippe
 }
 
 #[tauri::command]
-pub fn get_fillers(app: tauri::AppHandle) -> Result<Vec<crate::storage::FillerEntry>, String> {
+pub fn get_fillers(app: tauri::AppHandle) -> Result<crate::storage::FillersFile, String> {
     crate::storage::load_fillers(&app)
 }
 
 #[tauri::command]
-pub fn save_fillers(app: tauri::AppHandle, entries: Vec<crate::storage::FillerEntry>) -> Result<(), String> {
-    crate::storage::save_fillers(&app, &entries)
+pub fn save_fillers(
+    app: tauri::AppHandle,
+    fillers: crate::storage::FillersFile,
+) -> Result<(), String> {
+    crate::storage::save_fillers(&app, &fillers)
+}
+
+#[tauri::command]
+pub fn get_filler_suggestions(app: tauri::AppHandle) -> Result<Vec<String>, String> {
+    let history = crate::storage::load_history(&app)?;
+    let fillers = crate::storage::load_fillers(&app)?;
+    Ok(crate::fillers::compute_suggestions(&history, &fillers))
+}
+
+#[tauri::command]
+pub fn reject_filler_suggestion(app: tauri::AppHandle, word: String) -> Result<(), String> {
+    let mut fillers = crate::storage::load_fillers(&app)?;
+    let lower = word.to_lowercase();
+    if !fillers.rejected.iter().any(|w| w.to_lowercase() == lower) {
+        fillers.rejected.push(word);
+    }
+    crate::storage::save_fillers(&app, &fillers)
 }
 
 #[tauri::command]

--- a/src-tauri/src/fillers/mod.rs
+++ b/src-tauri/src/fillers/mod.rs
@@ -1,0 +1,278 @@
+//! Filler-word suggestion engine.
+//!
+//! Pure-statistical analysis over transcript history. Tokenises each
+//! `HistoryEntry.text` lowercase, counts occurrences of a fixed DE+EN
+//! seed list, and ranks the top candidates that the user has neither
+//! accepted (already on the manual list) nor rejected (dismissed
+//! previously). No NLP, no language detection, no network calls.
+
+use std::collections::HashSet;
+
+use crate::storage::{FillersFile, HistoryEntry};
+
+/// Fixed seed list of common DE + EN filler-word candidates. Multi-word
+/// phrases are matched as case-insensitive substrings; single words are
+/// matched against tokenised words via `is_alphabetic` boundaries.
+pub const SEED_FILLERS: &[&str] = &[
+    // German
+    "also",
+    "halt",
+    "ja",
+    "quasi",
+    "sozusagen",
+    "irgendwie",
+    "eigentlich",
+    "ne",
+    "weißt du",
+    "ähm",
+    "öhm",
+    // English
+    "um",
+    "uh",
+    "like",
+    "you know",
+    "basically",
+    "literally",
+    "actually",
+    "right",
+    "so",
+    "i mean",
+];
+
+/// Minimum total occurrences for a candidate to be suggested.
+const MIN_OCCURRENCES: usize = 5;
+
+/// Minimum number of distinct transcripts a candidate must appear in.
+/// Guards against suggestions that come from a single chatty transcript.
+const MIN_DISTINCT_TRANSCRIPTS: usize = 3;
+
+/// Maximum number of suggestions returned in one call.
+const MAX_SUGGESTIONS: usize = 10;
+
+/// Compute filler-word suggestions from history, excluding seeds that are
+/// already on the user's manual list (`fillers.words`) or that the user
+/// has previously rejected (`fillers.rejected`). Sorted by total count
+/// descending, with distinct-transcript count as the tiebreaker.
+pub fn compute_suggestions(history: &[HistoryEntry], fillers: &FillersFile) -> Vec<String> {
+    let accepted: HashSet<String> = fillers
+        .words
+        .iter()
+        .map(|e| e.word.to_lowercase())
+        .collect();
+    let rejected: HashSet<String> = fillers
+        .rejected
+        .iter()
+        .map(|w| w.to_lowercase())
+        .collect();
+
+    let mut scored: Vec<(String, usize, usize)> = SEED_FILLERS
+        .iter()
+        .filter_map(|seed| {
+            let lower = seed.to_lowercase();
+            if accepted.contains(&lower) || rejected.contains(&lower) {
+                return None;
+            }
+            let (count, distinct) = count_in_history(history, &lower);
+            if count < MIN_OCCURRENCES || distinct < MIN_DISTINCT_TRANSCRIPTS {
+                return None;
+            }
+            Some((seed.to_string(), count, distinct))
+        })
+        .collect();
+
+    scored.sort_by(|a, b| b.1.cmp(&a.1).then(b.2.cmp(&a.2)));
+    scored.truncate(MAX_SUGGESTIONS);
+    scored.into_iter().map(|(w, _, _)| w).collect()
+}
+
+/// Returns `(total_count, distinct_transcript_count)` for `seed_lower`
+/// across `history`. Phrases (containing whitespace) match as substrings;
+/// single words match on alphabetic boundaries.
+fn count_in_history(history: &[HistoryEntry], seed_lower: &str) -> (usize, usize) {
+    let is_phrase = seed_lower.contains(' ');
+    let mut total = 0usize;
+    let mut distinct = 0usize;
+    for entry in history {
+        let lower_text = entry.text.to_lowercase();
+        let occurrences = if is_phrase {
+            count_substring(&lower_text, seed_lower)
+        } else {
+            count_word(&lower_text, seed_lower)
+        };
+        if occurrences > 0 {
+            total += occurrences;
+            distinct += 1;
+        }
+    }
+    (total, distinct)
+}
+
+fn count_substring(haystack: &str, needle: &str) -> usize {
+    if needle.is_empty() {
+        return 0;
+    }
+    haystack.matches(needle).count()
+}
+
+fn count_word(text: &str, word: &str) -> usize {
+    text.split(|c: char| !c.is_alphabetic())
+        .filter(|tok| *tok == word)
+        .count()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::storage::FillerEntry;
+
+    fn entry(id: u64, text: &str) -> HistoryEntry {
+        HistoryEntry {
+            id: id.to_string(),
+            timestamp_ms: id,
+            text: text.into(),
+            enhanced: false,
+            duration_secs: 1.0,
+            word_count: text.split_whitespace().count() as u32,
+            provider: "test".into(),
+            target_app: None,
+        }
+    }
+
+    #[test]
+    fn ranks_by_total_count_desc() {
+        // "also" appears 6 times across 3 transcripts; "halt" 5 across 3.
+        // "also" should rank first.
+        let history = vec![
+            entry(1, "ich gehe also nach hause also wirklich"),
+            entry(2, "also kommt das halt darauf an halt"),
+            entry(3, "also halt halt"),
+        ];
+        let fillers = FillersFile::default();
+        let suggestions = compute_suggestions(&history, &fillers);
+        assert!(suggestions.contains(&"also".to_string()));
+        assert!(suggestions.contains(&"halt".to_string()));
+        let also_idx = suggestions.iter().position(|w| w == "also").unwrap();
+        let halt_idx = suggestions.iter().position(|w| w == "halt").unwrap();
+        assert!(also_idx < halt_idx, "also should rank above halt: {:?}", suggestions);
+    }
+
+    #[test]
+    fn excludes_already_accepted_words() {
+        let history = vec![
+            entry(1, "also also also"),
+            entry(2, "also also halt halt"),
+            entry(3, "also halt halt halt"),
+        ];
+        let fillers = FillersFile {
+            words: vec![FillerEntry {
+                id: "1".into(),
+                word: "also".into(),
+            }],
+            rejected: vec![],
+        };
+        let suggestions = compute_suggestions(&history, &fillers);
+        assert!(!suggestions.contains(&"also".to_string()));
+    }
+
+    #[test]
+    fn excludes_rejected_words() {
+        let history = vec![
+            entry(1, "also also also"),
+            entry(2, "also also halt halt"),
+            entry(3, "also halt halt halt"),
+        ];
+        let fillers = FillersFile {
+            words: vec![],
+            rejected: vec!["also".into()],
+        };
+        let suggestions = compute_suggestions(&history, &fillers);
+        assert!(!suggestions.contains(&"also".to_string()));
+    }
+
+    #[test]
+    fn rejection_match_is_case_insensitive() {
+        let history = vec![
+            entry(1, "Also Also Also"),
+            entry(2, "ALSO also Halt"),
+            entry(3, "also Halt halt"),
+        ];
+        let fillers = FillersFile {
+            words: vec![],
+            rejected: vec!["ALSO".into()],
+        };
+        let suggestions = compute_suggestions(&history, &fillers);
+        assert!(!suggestions.contains(&"also".to_string()));
+    }
+
+    #[test]
+    fn respects_min_occurrence_threshold() {
+        // "also" appears 4 times across 3 transcripts (count below min);
+        // "halt" appears 5 times across 3 transcripts (passes).
+        let history = vec![
+            entry(1, "also also halt halt"),
+            entry(2, "also halt halt"),
+            entry(3, "also halt"),
+        ];
+        let fillers = FillersFile::default();
+        let suggestions = compute_suggestions(&history, &fillers);
+        assert!(!suggestions.contains(&"also".to_string()));
+        assert!(suggestions.contains(&"halt".to_string()));
+    }
+
+    #[test]
+    fn respects_min_distinct_transcripts_threshold() {
+        // "also" appears 8 times but only in 2 distinct transcripts.
+        let history = vec![
+            entry(1, "also also also also"),
+            entry(2, "also also also also"),
+        ];
+        let fillers = FillersFile::default();
+        let suggestions = compute_suggestions(&history, &fillers);
+        assert!(!suggestions.contains(&"also".to_string()));
+    }
+
+    #[test]
+    fn handles_multiword_phrases_via_substring() {
+        let history = vec![
+            entry(1, "i mean it's complicated, i mean it"),
+            entry(2, "well, i mean i think so"),
+            entry(3, "i mean really, i mean"),
+        ];
+        let fillers = FillersFile::default();
+        let suggestions = compute_suggestions(&history, &fillers);
+        assert!(suggestions.contains(&"i mean".to_string()));
+    }
+
+    #[test]
+    fn word_match_respects_alphabetic_boundaries() {
+        // "so" should not match "soccer", "sole", or "solid".
+        let history = vec![
+            entry(1, "soccer is fun, sole purpose, solid plan"),
+            entry(2, "she sold soap to soldiers"),
+            entry(3, "solar systems and solo gigs"),
+        ];
+        let fillers = FillersFile::default();
+        let suggestions = compute_suggestions(&history, &fillers);
+        assert!(!suggestions.contains(&"so".to_string()));
+    }
+
+    #[test]
+    fn empty_history_returns_no_suggestions() {
+        let fillers = FillersFile::default();
+        let suggestions = compute_suggestions(&[], &fillers);
+        assert!(suggestions.is_empty());
+    }
+
+    #[test]
+    fn caps_at_max_suggestions() {
+        // Synthetic: every seed appears 10x in 10 distinct transcripts.
+        let mut history = vec![];
+        let chunk = SEED_FILLERS.join(" ").repeat(10);
+        for i in 0..10 {
+            history.push(entry(i, &chunk));
+        }
+        let fillers = FillersFile::default();
+        let suggestions = compute_suggestions(&history, &fillers);
+        assert!(suggestions.len() <= MAX_SUGGESTIONS, "got {} suggestions", suggestions.len());
+    }
+}

--- a/src-tauri/src/fillers/mod.rs
+++ b/src-tauri/src/fillers/mod.rs
@@ -141,16 +141,25 @@ mod tests {
     #[test]
     fn ranks_by_total_count_desc() {
         // "also" appears 6 times across 3 transcripts; "halt" 5 across 3.
-        // "also" should rank first.
+        // Both clear the min-occurrences (5) and min-distinct (3) thresholds;
+        // "also" should rank above "halt".
         let history = vec![
-            entry(1, "ich gehe also nach hause also wirklich"),
-            entry(2, "also kommt das halt darauf an halt"),
-            entry(3, "also halt halt"),
+            entry(1, "also also also halt halt"),
+            entry(2, "also also halt halt"),
+            entry(3, "also halt"),
         ];
         let fillers = FillersFile::default();
         let suggestions = compute_suggestions(&history, &fillers);
-        assert!(suggestions.contains(&"also".to_string()));
-        assert!(suggestions.contains(&"halt".to_string()));
+        assert!(
+            suggestions.contains(&"also".to_string()),
+            "expected `also` in suggestions, got {:?}",
+            suggestions
+        );
+        assert!(
+            suggestions.contains(&"halt".to_string()),
+            "expected `halt` in suggestions, got {:?}",
+            suggestions
+        );
         let also_idx = suggestions.iter().position(|w| w == "also").unwrap();
         let halt_idx = suggestions.iter().position(|w| w == "halt").unwrap();
         assert!(also_idx < halt_idx, "also should rank above halt: {:?}", suggestions);

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -4,6 +4,7 @@ pub mod audio_ducking;
 pub mod clipboard;
 pub mod commands;
 pub mod errors;
+pub mod fillers;
 pub mod hotkey;
 pub mod keychain;
 pub mod local_transcription;
@@ -240,6 +241,8 @@ pub fn run() {
             commands::save_snippets,
             commands::get_fillers,
             commands::save_fillers,
+            commands::get_filler_suggestions,
+            commands::reject_filler_suggestion,
             commands::get_autostart,
             commands::set_autostart,
             commands::get_history,

--- a/src-tauri/src/storage/mod.rs
+++ b/src-tauri/src/storage/mod.rs
@@ -236,6 +236,17 @@ pub struct FillerEntry {
     pub word: String,
 }
 
+/// On-disk shape for `fillers.json`. Migrated silently from the legacy
+/// flat-array format on first load after update.
+#[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FillersFile {
+    #[serde(default)]
+    pub words: Vec<FillerEntry>,
+    #[serde(default)]
+    pub rejected: Vec<String>,
+}
+
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct HistoryEntry {
@@ -322,11 +333,11 @@ pub fn load_dictionary(app: &AppHandle) -> Result<Vec<DictionaryEntry>, String> 
 pub fn save_dictionary(app: &AppHandle, entries: &[DictionaryEntry]) -> Result<(), String> {
     save_to_path_raw(&dictionary_path(app)?, entries)
 }
-pub fn load_fillers(app: &AppHandle) -> Result<Vec<FillerEntry>, String> {
-    load_vec_from_path(&fillers_path(app)?)
+pub fn load_fillers(app: &AppHandle) -> Result<FillersFile, String> {
+    load_fillers_from_path(&fillers_path(app)?)
 }
-pub fn save_fillers(app: &AppHandle, entries: &[FillerEntry]) -> Result<(), String> {
-    save_to_path_raw(&fillers_path(app)?, entries)
+pub fn save_fillers(app: &AppHandle, fillers: &FillersFile) -> Result<(), String> {
+    save_to_path_raw(&fillers_path(app)?, fillers)
 }
 pub fn load_history(app: &AppHandle) -> Result<Vec<HistoryEntry>, String> {
     load_vec_from_path(&history_path(app)?)
@@ -435,6 +446,25 @@ where
     }
     let content = std::fs::read_to_string(path).map_err(|e| format!("STORAGE_ERROR: {e}"))?;
     serde_json::from_str(&content).map_err(|e| format!("STORAGE_ERROR: {e}"))
+}
+
+/// Load `fillers.json`, migrating the legacy flat-array shape
+/// (`[FillerEntry, …]`) to the current object shape silently. The migrated
+/// content is not written back here — the next `save_fillers` call writes
+/// the new shape on its own.
+pub(crate) fn load_fillers_from_path(path: &Path) -> Result<FillersFile, String> {
+    if !path.exists() {
+        return Ok(FillersFile::default());
+    }
+    let content = std::fs::read_to_string(path).map_err(|e| format!("STORAGE_ERROR: {e}"))?;
+    let value: serde_json::Value =
+        serde_json::from_str(&content).map_err(|e| format!("STORAGE_ERROR: {e}"))?;
+    if value.is_array() {
+        let words: Vec<FillerEntry> = serde_json::from_value(value)
+            .map_err(|e| format!("STORAGE_ERROR: {e}"))?;
+        return Ok(FillersFile { words, rejected: Vec::new() });
+    }
+    serde_json::from_value(value).map_err(|e| format!("STORAGE_ERROR: {e}"))
 }
 
 pub(crate) fn save_to_path_raw<T: serde::Serialize + ?Sized>(path: &Path, value: &T) -> Result<(), String> {
@@ -867,5 +897,80 @@ mod tests {
         std::fs::write(&path, "{not an array}").unwrap();
         let result: Result<Vec<Snippet>, _> = load_vec_from_path(&path);
         assert!(result.is_err());
+    }
+
+    // ── fillers.json migration ────────────────────────────────────────────────
+
+    #[test]
+    fn load_fillers_returns_default_when_file_missing() {
+        let dir = tmp();
+        let path = dir.path().join("fillers.json");
+        let loaded = load_fillers_from_path(&path).unwrap();
+        assert!(loaded.words.is_empty());
+        assert!(loaded.rejected.is_empty());
+    }
+
+    #[test]
+    fn load_fillers_migrates_legacy_flat_array() {
+        let dir = tmp();
+        let path = dir.path().join("fillers.json");
+        // Pre-#35 format: a flat array of FillerEntry.
+        let legacy = serde_json::json!([
+            { "id": "1", "word": "ähm" },
+            { "id": "2", "word": "halt" }
+        ]);
+        std::fs::write(&path, serde_json::to_string(&legacy).unwrap()).unwrap();
+
+        let loaded = load_fillers_from_path(&path).unwrap();
+        assert_eq!(loaded.words.len(), 2);
+        assert_eq!(loaded.words[0].word, "ähm");
+        assert_eq!(loaded.words[1].word, "halt");
+        assert!(loaded.rejected.is_empty());
+    }
+
+    #[test]
+    fn load_fillers_loads_new_object_format() {
+        let dir = tmp();
+        let path = dir.path().join("fillers.json");
+        let new_format = serde_json::json!({
+            "words": [{ "id": "1", "word": "halt" }],
+            "rejected": ["also", "ja"]
+        });
+        std::fs::write(&path, serde_json::to_string(&new_format).unwrap()).unwrap();
+
+        let loaded = load_fillers_from_path(&path).unwrap();
+        assert_eq!(loaded.words.len(), 1);
+        assert_eq!(loaded.words[0].word, "halt");
+        assert_eq!(loaded.rejected, vec!["also".to_string(), "ja".to_string()]);
+    }
+
+    #[test]
+    fn load_fillers_handles_object_without_rejected_key() {
+        // Defensive: an upgrade path could write `{ words: [...] }` without
+        // `rejected` if a future version of the schema were ever rolled back
+        // by hand. `#[serde(default)]` makes that load cleanly.
+        let dir = tmp();
+        let path = dir.path().join("fillers.json");
+        let partial = serde_json::json!({ "words": [{ "id": "1", "word": "uh" }] });
+        std::fs::write(&path, serde_json::to_string(&partial).unwrap()).unwrap();
+
+        let loaded = load_fillers_from_path(&path).unwrap();
+        assert_eq!(loaded.words.len(), 1);
+        assert!(loaded.rejected.is_empty());
+    }
+
+    #[test]
+    fn save_fillers_roundtrip_preserves_rejected_list() {
+        let dir = tmp();
+        let path = dir.path().join("fillers.json");
+        let fillers = FillersFile {
+            words: vec![FillerEntry { id: "1".into(), word: "halt".into() }],
+            rejected: vec!["also".into()],
+        };
+        save_to_path_raw(&path, &fillers).unwrap();
+        let loaded = load_fillers_from_path(&path).unwrap();
+        assert_eq!(loaded.words.len(), 1);
+        assert_eq!(loaded.words[0].word, "halt");
+        assert_eq!(loaded.rejected, vec!["also".to_string()]);
     }
 }

--- a/src-tauri/src/transcription/mod.rs
+++ b/src-tauri/src/transcription/mod.rs
@@ -646,10 +646,10 @@ fn maybe_remove_fillers(
         return text;
     }
     let fillers = match crate::storage::load_fillers(app) {
-        Ok(list) => list,
+        Ok(file) => file,
         Err(_) => return text,
     };
-    let words: Vec<String> = fillers.into_iter().map(|e| e.word).collect();
+    let words: Vec<String> = fillers.words.into_iter().map(|e| e.word).collect();
     apply_fillers_to_text(text, &words)
 }
 

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -291,7 +291,13 @@
       "description": "Wörter aus dieser Liste werden vor der KI-Nachbearbeitung aus der Transkription entfernt, wenn der Toggle oben rechts aktiv ist.",
       "wordPlaceholder": "z. B. also, halt, quasi",
       "add": "Hinzufügen",
-      "empty": "Noch keine Füllwörter. Typische Kandidaten: also, halt, ja, quasi, sozusagen, irgendwie, eigentlich, um, uh, ähm, like, you know."
+      "empty": "Noch keine Füllwörter. Typische Kandidaten: also, halt, ja, quasi, sozusagen, irgendwie, eigentlich, um, uh, ähm, like, you know.",
+      "suggested": {
+        "title": "Vorschläge",
+        "description": "Aus deinem Transkript-Verlauf erkannt — häufige Füllwörter, die noch nicht in deiner Liste sind.",
+        "accept": "Übernehmen",
+        "reject": "Ausblenden"
+      }
     }
   },
   "errors": {

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -291,7 +291,13 @@
       "description": "Words on this list are stripped from the transcription before AI enhancement runs, when the toggle in the top right is on.",
       "wordPlaceholder": "e.g. um, uh, like, basically",
       "add": "Add",
-      "empty": "No filler words yet. Common candidates: um, uh, like, you know, basically, literally, actually, right, so, also, halt, quasi."
+      "empty": "No filler words yet. Common candidates: um, uh, like, you know, basically, literally, actually, right, so, also, halt, quasi.",
+      "suggested": {
+        "title": "Suggested",
+        "description": "Picked up from your transcript history — common fillers that aren't on your list yet.",
+        "accept": "Add",
+        "reject": "Hide"
+      }
     }
   },
   "errors": {

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -291,7 +291,13 @@
       "description": "Las palabras de esta lista se eliminan de la transcripción antes de que se ejecute la mejora con IA, si el toggle superior derecho está activo.",
       "wordPlaceholder": "p. ej. eh, o sea, tipo, vale",
       "add": "Añadir",
-      "empty": "Aún no hay muletillas. Candidatas típicas: eh, o sea, tipo, vale, pues, bueno, vaya, literalmente, básicamente, en plan."
+      "empty": "Aún no hay muletillas. Candidatas típicas: eh, o sea, tipo, vale, pues, bueno, vaya, literalmente, básicamente, en plan.",
+      "suggested": {
+        "title": "Sugerencias",
+        "description": "Detectadas en tu historial de transcripciones — muletillas frecuentes que aún no están en tu lista.",
+        "accept": "Añadir",
+        "reject": "Ocultar"
+      }
     }
   },
   "errors": {

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -291,7 +291,13 @@
       "description": "Les mots de cette liste sont retirés de la transcription avant l'amélioration IA, si le toggle en haut à droite est actif.",
       "wordPlaceholder": "p. ex. euh, bah, genre, du coup",
       "add": "Ajouter",
-      "empty": "Aucun mot-béquille pour l'instant. Candidats typiques : euh, bah, genre, du coup, voilà, en fait, quoi, bon, tu vois, style."
+      "empty": "Aucun mot-béquille pour l'instant. Candidats typiques : euh, bah, genre, du coup, voilà, en fait, quoi, bon, tu vois, style.",
+      "suggested": {
+        "title": "Suggestions",
+        "description": "Repérés dans votre historique de transcription — mots-béquilles fréquents qui ne figurent pas encore dans votre liste.",
+        "accept": "Ajouter",
+        "reject": "Masquer"
+      }
     }
   },
   "errors": {

--- a/src/i18n/locales/it.json
+++ b/src/i18n/locales/it.json
@@ -291,7 +291,13 @@
       "description": "Le parole in questo elenco vengono rimosse dalla trascrizione prima del miglioramento IA, quando il toggle in alto a destra è attivo.",
       "wordPlaceholder": "p. es. ehm, tipo, cioè, praticamente",
       "add": "Aggiungi",
-      "empty": "Nessun intercalare ancora. Candidati tipici: ehm, tipo, cioè, praticamente, insomma, letteralmente, diciamo, ecco, capito, come dire."
+      "empty": "Nessun intercalare ancora. Candidati tipici: ehm, tipo, cioè, praticamente, insomma, letteralmente, diciamo, ecco, capito, come dire.",
+      "suggested": {
+        "title": "Suggeriti",
+        "description": "Rilevati dalla tua cronologia di trascrizioni — intercalari frequenti non ancora presenti nella tua lista.",
+        "accept": "Aggiungi",
+        "reject": "Nascondi"
+      }
     }
   },
   "errors": {

--- a/src/i18n/locales/pt.json
+++ b/src/i18n/locales/pt.json
@@ -291,7 +291,13 @@
       "description": "As palavras nesta lista são removidas da transcrição antes da melhoria por IA, se o toggle no canto superior direito estiver ativo.",
       "wordPlaceholder": "p. ex. tipo, pá, sabes, então",
       "add": "Adicionar",
-      "empty": "Ainda não há muletas. Candidatas típicas: tipo, pá, sabes, então, pronto, enfim, literalmente, basicamente, na boa."
+      "empty": "Ainda não há muletas. Candidatas típicas: tipo, pá, sabes, então, pronto, enfim, literalmente, basicamente, na boa.",
+      "suggested": {
+        "title": "Sugestões",
+        "description": "Detetadas no teu histórico de transcrições — muletas frequentes que ainda não estão na tua lista.",
+        "accept": "Adicionar",
+        "reject": "Ocultar"
+      }
     }
   },
   "errors": {

--- a/src/pages/settings/FillersSettings.tsx
+++ b/src/pages/settings/FillersSettings.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { invoke } from '@tauri-apps/api/core'
-import type { FillerEntry, Settings } from '../../types'
+import type { FillerEntry, FillersFile, Settings } from '../../types'
 
 interface Props {
   settings: Settings
@@ -10,35 +10,65 @@ interface Props {
 
 export function FillersSettings({ settings, onChange }: Props) {
   const { t } = useTranslation()
-  const [entries, setEntries] = useState<FillerEntry[]>([])
+  const [words, setWords] = useState<FillerEntry[]>([])
+  const [rejected, setRejected] = useState<string[]>([])
+  const [suggestions, setSuggestions] = useState<string[]>([])
   const [input, setInput] = useState('')
   const inputRef = useRef<HTMLInputElement>(null)
 
   const enabled = settings.transcription?.removeFillerWords ?? false
+  const historyTracking = settings.privacy?.historyTracking ?? true
 
   useEffect(() => {
-    invoke<FillerEntry[]>('get_fillers').then(setEntries).catch(console.error)
+    invoke<FillersFile>('get_fillers')
+      .then((file) => {
+        setWords(file.words)
+        setRejected(file.rejected)
+      })
+      .catch(console.error)
   }, [])
 
-  async function persist(updated: FillerEntry[]) {
-    setEntries(updated)
-    await invoke('save_fillers', { entries: updated })
+  useEffect(() => {
+    if (!historyTracking) {
+      setSuggestions([])
+      return
+    }
+    invoke<string[]>('get_filler_suggestions').then(setSuggestions).catch(console.error)
+  }, [historyTracking])
+
+  async function persistWords(updatedWords: FillerEntry[]) {
+    setWords(updatedWords)
+    await invoke('save_fillers', { fillers: { words: updatedWords, rejected } })
   }
 
   async function handleAdd() {
     const word = input.trim()
     if (!word) return
-    if (entries.some((e) => e.word.toLowerCase() === word.toLowerCase())) {
+    if (words.some((e) => e.word.toLowerCase() === word.toLowerCase())) {
       setInput('')
       return
     }
-    await persist([...entries, { id: crypto.randomUUID(), word }])
+    await persistWords([...words, { id: crypto.randomUUID(), word }])
     setInput('')
     inputRef.current?.focus()
   }
 
   async function handleDelete(id: string) {
-    await persist(entries.filter((e) => e.id !== id))
+    await persistWords(words.filter((e) => e.id !== id))
+  }
+
+  async function handleAcceptSuggestion(word: string) {
+    setSuggestions(suggestions.filter((s) => s !== word))
+    if (words.some((e) => e.word.toLowerCase() === word.toLowerCase())) {
+      return
+    }
+    await persistWords([...words, { id: crypto.randomUUID(), word }])
+  }
+
+  async function handleRejectSuggestion(word: string) {
+    setSuggestions(suggestions.filter((s) => s !== word))
+    setRejected([...rejected, word])
+    await invoke('reject_filler_suggestion', { word })
   }
 
   function toggleEnabled() {
@@ -47,6 +77,8 @@ export function FillersSettings({ settings, onChange }: Props) {
       transcription: { ...settings.transcription, removeFillerWords: !enabled },
     })
   }
+
+  const showSuggested = historyTracking && suggestions.length > 0
 
   return (
     <div>
@@ -64,6 +96,42 @@ export function FillersSettings({ settings, onChange }: Props) {
       <p className="text-xs text-text-muted mb-4">
         {t('settings.fillers.description')}
       </p>
+
+      {showSuggested && (
+        <div style={{ opacity: enabled ? 1 : 0.55, marginBottom: 24 }}>
+          <p className="sec-head">{t('settings.fillers.suggested.title')}</p>
+          <p className="text-xs text-text-muted mb-3">
+            {t('settings.fillers.suggested.description')}
+          </p>
+          <div className="flex flex-wrap gap-1.5">
+            {suggestions.map((word) => (
+              <div
+                key={word}
+                className="flex items-center gap-1 px-2.5 py-1 rounded-full border border-border bg-surface"
+              >
+                <span className="text-xs text-text">{word}</span>
+                <button
+                  onClick={() => handleAcceptSuggestion(word)}
+                  disabled={!enabled}
+                  className="text-text-muted hover:text-accent transition-colors text-xs leading-none disabled:cursor-not-allowed ml-0.5"
+                  aria-label={t('settings.fillers.suggested.accept')}
+                  title={t('settings.fillers.suggested.accept')}
+                >
+                  +
+                </button>
+                <button
+                  onClick={() => handleRejectSuggestion(word)}
+                  className="text-text-muted hover:text-red-400 transition-colors text-xs leading-none"
+                  aria-label={t('settings.fillers.suggested.reject')}
+                  title={t('settings.fillers.suggested.reject')}
+                >
+                  ×
+                </button>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
 
       <div className="flex gap-2 mb-4" style={{ opacity: enabled ? 1 : 0.55 }}>
         <input
@@ -84,9 +152,9 @@ export function FillersSettings({ settings, onChange }: Props) {
         </button>
       </div>
 
-      {entries.length > 0 ? (
+      {words.length > 0 ? (
         <div className="flex flex-wrap gap-1.5" style={{ opacity: enabled ? 1 : 0.55 }}>
-          {entries.map((entry) => (
+          {words.map((entry) => (
             <div
               key={entry.id}
               className="flex items-center gap-1 px-2.5 py-1 rounded-full border border-border bg-surface-raised group"

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -17,6 +17,11 @@ export interface FillerEntry {
   word: string
 }
 
+export interface FillersFile {
+  words: FillerEntry[]
+  rejected: string[]
+}
+
 export interface AIPrompt {
   id: string
   name: string


### PR DESCRIPTION
  Adds a "Suggested" section on the Fillers settings page that surfaces filler-word candidates from the user's local transcript history. Pure-statistical, opt-in via the existing privacy.historyTracking flag, all
   data stays local.                                                                                                                                                                                                
  
  ## Highlights                                                                                                                                                                                                     
                                                                  
  - **New Rust module `fillers/`** — fixed DE+EN seed list, tokeniser with alphabetic-boundary matching for single words and case-insensitive substring for multi-word phrases ("you know", "i mean"). Thresholds:  
  ≥5 occurrences across ≥3 distinct transcripts, capped at 10 suggestions
  - **Silent storage migration** — `fillers.json` flat array → `{ words, rejected }`. Both fields `#[serde(default)]` for forward/backward robustness. No prompt, no data loss, no follow-up write needed; the next 
  save lays down the new shape                                                                                                                                                                                      
  - **Two new IPC commands** — `get_filler_suggestions` returns the ranked top-N words; `reject_filler_suggestion` persists a dismissal so it never re-surfaces
  - **Frontend** — Suggested section appears between the page description and the manual input. Conditionally rendered only when `privacy.historyTracking` is on. No nag, no empty state when the toggle is off     
  - **i18n** — all six locales (DE/EN/ES/FR/PT/IT) get matching strings for section title, description, Add and Hide                                                                                                
                                                                                                                                                                                                                    
  ## Privacy & defaults                                                                                                                                                                                             
                                                                                                                                                                                                                    
  The feature respects existing privacy defaults. `privacy.historyTracking` already gates whether transcripts get persisted at all; this PR adds nothing new the user has to opt into. When historyTracking is off  
  the Suggested section is absent — no toggle, no copy nudging the user to enable it.
                                                                                                                                                                                                                    
  ## Behaviour                                                    

  - Suggestions refresh on page mount only — no background polling, no CPU at idle                                                                                                                                  
  - Rejecting a suggestion adds the word to `fillers.rejected`. Future page opens skip it
  - Accepting moves the word into the manual list with a fresh UUID. Same effect as typing it manually                                                                                                              
  - Words already in `words[]` and words in `rejected[]` are both filtered out before ranking, regardless of casing                                                                                                 
                                                                                                                                                                                                                    
  ## Tests                                                                                                                                                                                                          
                                                                                                                                                                                                                    
  Rust unit tests cover both layers:                              
  - **Storage migration** — legacy flat-array load, new-format load, partial-shape robustness (`{}`, missing `rejected`), roundtrip
  - **Suggestion engine** — count-descending rank, accepted-exclusion, rejected-exclusion (case-insensitive), min-occurrence and min-distinct-transcript thresholds, multi-word phrase matching, alphabetic-boundary
   discipline (no false positives like "soccer" matching "so"), max-suggestions cap, empty-history handling                                                                                                         
                                                                                                                                                                                                                    
  Frontend `tsc --noEmit` passes locally.                         
                                                                                                                                                                                                                    
  ## Test plan (manual)                                           
                                                                                                                                                                                                                    
  - [ ] Fresh install: Suggested section absent until enough history accumulates
  - [ ] After ≥3 transcripts with seed-list words: section appears with ranked suggestions                                                                                                                          
  - [ ] Accept a suggestion → moves to manual list, removed from Suggested                
  - [ ] Reject a suggestion → disappears, doesn't return on page reopen                                                                                                                                             
  - [ ] Toggle `privacy.historyTracking` off in General settings → Suggested section disappears, manual list still works                                                                                            
  - [ ] Upgrade path: old install with flat-array `fillers.json` → loads cleanly, manual list unchanged, no error                                                                                                   
  - [ ] Locale switch covers DE/EN at minimum; spot-check ES/FR/PT/IT strings render                                                                                                                                
                                                                                                                                                                                                                    
  closes #35