### PR TITLE
feat(updater): tauri auto-updater with manual check, opt-in auto-check, and pill speech bubble

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,6 +54,9 @@ jobs:
         run: rm -rf src-tauri/target/release/bundle
 
       - name: Build Tauri app (NSIS, unsigned)
+        env:
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
         run: npm run tauri build -- --bundles nsis
 
       - name: Upload installer artifact
@@ -82,6 +85,42 @@ jobs:
             --output cyclonedx-json=sbom.cyclonedx.json \
             --output spdx-json=sbom.spdx.json
 
+      - name: Compose latest.json updater manifest
+        if: startsWith(github.ref, 'refs/tags/v')
+        shell: bash
+        run: |
+          set -e
+          VERSION="${GITHUB_REF#refs/tags/v}"
+          INSTALLER=$(ls src-tauri/target/release/bundle/nsis/*-setup.exe | head -1)
+          SIG_FILE="${INSTALLER}.sig"
+          if [ ! -f "$SIG_FILE" ]; then
+            echo "ERROR: signature file not found at $SIG_FILE"
+            echo "TAURI_SIGNING_PRIVATE_KEY secret may not be set, or the build did not sign."
+            exit 1
+          fi
+          INSTALLER_NAME=$(basename "$INSTALLER")
+          INSTALLER_URL="https://github.com/fnnbl/voca-app/releases/download/v${VERSION}/${INSTALLER_NAME}"
+          PUB_DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+          jq -n \
+            --arg version "$VERSION" \
+            --arg notes "See the GitHub release for changes." \
+            --arg pub_date "$PUB_DATE" \
+            --rawfile signature "$SIG_FILE" \
+            --arg url "$INSTALLER_URL" \
+            '{
+              version: $version,
+              notes: $notes,
+              pub_date: $pub_date,
+              platforms: {
+                "windows-x86_64": {
+                  signature: $signature,
+                  url: $url
+                }
+              }
+            }' > latest.json
+          echo "--- latest.json ---"
+          cat latest.json
+
       - name: Publish draft release
         if: startsWith(github.ref, 'refs/tags/v')
         uses: softprops/action-gh-release@v2
@@ -90,6 +129,7 @@ jobs:
             src-tauri/target/release/bundle/nsis/*.exe
             sbom.cyclonedx.json
             sbom.spdx.json
+            latest.json
           generate_release_notes: true
           draft: true
           prerelease: ${{ contains(github.ref_name, '-') }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,9 @@
       "version": "0.3.2",
       "dependencies": {
         "@tauri-apps/api": "^2.0.0",
+        "@tauri-apps/plugin-process": "^2.3.1",
         "@tauri-apps/plugin-shell": "^2.0.0",
+        "@tauri-apps/plugin-updater": "^2.10.1",
         "i18next": "^23.16.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
@@ -1892,10 +1894,28 @@
         "node": ">= 10"
       }
     },
+    "node_modules/@tauri-apps/plugin-process": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/plugin-process/-/plugin-process-2.3.1.tgz",
+      "integrity": "sha512-nCa4fGVaDL/B9ai03VyPOjfAHRHSBz5v6F/ObsB73r/dA3MHHhZtldaDMIc0V/pnUw9ehzr2iEG+XkSEyC0JJA==",
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "@tauri-apps/api": "^2.8.0"
+      }
+    },
     "node_modules/@tauri-apps/plugin-shell": {
       "version": "2.3.5",
       "resolved": "https://registry.npmjs.org/@tauri-apps/plugin-shell/-/plugin-shell-2.3.5.tgz",
       "integrity": "sha512-jewtULhiQ7lI7+owCKAjc8tYLJr92U16bPOeAa472LHJdgaibLP83NcfAF2e+wkEcA53FxKQAZ7byDzs2eeizg==",
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "@tauri-apps/api": "^2.10.1"
+      }
+    },
+    "node_modules/@tauri-apps/plugin-updater": {
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/plugin-updater/-/plugin-updater-2.10.1.tgz",
+      "integrity": "sha512-NFYMg+tWOZPJdzE/PpFj2qfqwAWwNS3kXrb1tm1gnBJ9mYzZ4WDRrwy8udzWoAnfGCHLuePNLY1WVCNHnh3eRA==",
       "license": "MIT OR Apache-2.0",
       "dependencies": {
         "@tauri-apps/api": "^2.10.1"

--- a/package.json
+++ b/package.json
@@ -17,7 +17,9 @@
   },
   "dependencies": {
     "@tauri-apps/api": "^2.0.0",
+    "@tauri-apps/plugin-process": "^2.3.1",
     "@tauri-apps/plugin-shell": "^2.0.0",
+    "@tauri-apps/plugin-updater": "^2.10.1",
     "i18next": "^23.16.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -81,6 +81,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+dependencies = [
+ "derive_arbitrary",
+]
+
+[[package]]
 name = "arboard"
 version = "3.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1090,6 +1099,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "derive_more"
 version = "0.99.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1474,6 +1494,17 @@ checksum = "38e2275cc4e4fc009b0669731a1e5ab7ebf11f469eaede2bab9309a5b4d6057f"
 dependencies = [
  "memoffset 0.9.1",
  "rustc_version",
+]
+
+[[package]]
+name = "filetime"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f98844151eee8917efc50bd9e8318cb963ae8b297431495d3f758616ea5c57db"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "libredox",
 ]
 
 [[package]]
@@ -2626,7 +2657,7 @@ dependencies = [
  "lazy_static",
  "linux-keyutils",
  "secret-service",
- "security-framework",
+ "security-framework 2.11.1",
  "windows-sys 0.52.0",
 ]
 
@@ -2710,7 +2741,10 @@ version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
 dependencies = [
+ "bitflags 2.11.1",
  "libc",
+ "plain",
+ "redox_syscall 0.7.5",
 ]
 
 [[package]]
@@ -2900,6 +2934,12 @@ name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
+name = "minisign-verify"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22f9645cb765ea72b8111f36c522475d2daa0d22c957a9826437e97534bc4e9e"
 
 [[package]]
 name = "miniz_oxide"
@@ -3343,6 +3383,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-osa-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f112d1746737b0da274ef79a23aac283376f335f4095a083a267a082f21db0c0"
+dependencies = [
+ "bitflags 2.11.1",
+ "objc2 0.6.4",
+ "objc2-app-kit 0.3.2",
+ "objc2-foundation 0.3.2",
+]
+
+[[package]]
 name = "objc2-quartz-core"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3435,6 +3487,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
 name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3458,6 +3516,20 @@ checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "osakit"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "732c71caeaa72c065bb69d7ea08717bd3f4863a4f451402fc9513e29dbd5261b"
+dependencies = [
+ "objc2 0.6.4",
+ "objc2-foundation 0.3.2",
+ "objc2-osa-kit",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -3509,7 +3581,7 @@ checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.5.18",
  "smallvec",
  "windows-link 0.2.1",
 ]
@@ -3735,6 +3807,12 @@ name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+
+[[package]]
+name = "plain"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "plist"
@@ -4161,6 +4239,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4666a1a60d8412eab19d94f6d13dcc9cea0a5ef4fdf6a5db306537413c661b1b"
+dependencies = [
+ "bitflags 2.11.1",
+]
+
+[[package]]
 name = "redox_users"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4285,15 +4372,20 @@ dependencies = [
  "http-body",
  "http-body-util",
  "hyper",
+ "hyper-rustls",
  "hyper-util",
  "js-sys",
  "log",
  "percent-encoding",
  "pin-project-lite",
+ "rustls",
+ "rustls-pki-types",
+ "rustls-platform-verifier",
  "serde",
  "serde_json",
  "sync_wrapper",
  "tokio",
+ "tokio-rustls",
  "tokio-util",
  "tower",
  "tower-http",
@@ -4389,6 +4481,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-native-certs"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework 3.7.0",
+]
+
+[[package]]
 name = "rustls-pki-types"
 version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4397,6 +4501,33 @@ dependencies = [
  "web-time",
  "zeroize",
 ]
+
+[[package]]
+name = "rustls-platform-verifier"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d99feebc72bae7ab76ba994bb5e121b8d83d910ca40b36e0921f53becc41784"
+dependencies = [
+ "core-foundation 0.10.1",
+ "core-foundation-sys 0.8.7",
+ "jni",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework 3.7.0",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
@@ -4428,6 +4559,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4514,6 +4654,19 @@ checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
  "bitflags 2.11.1",
  "core-foundation 0.9.4",
+ "core-foundation-sys 0.8.7",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags 2.11.1",
+ "core-foundation 0.10.1",
  "core-foundation-sys 0.8.7",
  "libc",
  "security-framework-sys",
@@ -4890,7 +5043,7 @@ dependencies = [
  "objc2-foundation 0.3.2",
  "objc2-quartz-core 0.3.2",
  "raw-window-handle",
- "redox_syscall",
+ "redox_syscall 0.5.18",
  "tracing",
  "wasm-bindgen",
  "web-sys",
@@ -5112,6 +5265,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tar"
+version = "0.4.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22692a6476a21fa75fdfc11d452fda482af402c008cdbaf3476414e122040973"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
+]
+
+[[package]]
 name = "target-lexicon"
 version = "0.12.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5283,6 +5447,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-process"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d55511a7bf6cd70c8767b02c97bf8134fa434daf3926cfc1be0a0f94132d165a"
+dependencies = [
+ "tauri",
+ "tauri-plugin",
+]
+
+[[package]]
 name = "tauri-plugin-shell"
 version = "2.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5301,6 +5475,39 @@ dependencies = [
  "tauri-plugin",
  "thiserror 2.0.18",
  "tokio",
+]
+
+[[package]]
+name = "tauri-plugin-updater"
+version = "2.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "806d9dac662c2e4594ff03c647a552f2c9bd544e7d0f683ec58f872f952ce4af"
+dependencies = [
+ "base64 0.22.1",
+ "dirs 6.0.0",
+ "flate2",
+ "futures-util",
+ "http",
+ "infer",
+ "log",
+ "minisign-verify",
+ "osakit",
+ "percent-encoding",
+ "reqwest 0.13.2",
+ "rustls",
+ "semver",
+ "serde",
+ "serde_json",
+ "tar",
+ "tauri",
+ "tauri-plugin",
+ "tempfile",
+ "thiserror 2.0.18",
+ "time",
+ "tokio",
+ "url",
+ "windows-sys 0.60.2",
+ "zip",
 ]
 
 [[package]]
@@ -5984,7 +6191,9 @@ dependencies = [
  "tauri-build",
  "tauri-plugin-autostart",
  "tauri-plugin-notification",
+ "tauri-plugin-process",
  "tauri-plugin-shell",
+ "tauri-plugin-updater",
  "tempfile",
  "tokio",
  "whisper-rs",
@@ -6242,6 +6451,15 @@ dependencies = [
  "pkg-config",
  "soup3-sys",
  "system-deps",
+]
+
+[[package]]
+name = "webpki-root-certs"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -7183,6 +7401,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea6fc2961e4ef194dcbfe56bb845534d0dc8098940c7e5c012a258bfec6701bd"
 
 [[package]]
+name = "xattr"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
+dependencies = [
+ "libc",
+ "rustix 1.1.4",
+]
+
+[[package]]
 name = "xdg-home"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7437,6 +7665,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "zip"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa8cd6af31c3b31c6631b8f483848b91589021b28fffe50adada48d4f4d2ed1"
+dependencies = [
+ "arbitrary",
+ "crc32fast",
+ "indexmap 2.14.0",
+ "memchr",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -21,7 +21,9 @@ tauri-build = { version = "2", features = [] }
 tauri = { version = "2", features = ["tray-icon", "image-png"] }
 tauri-plugin-autostart = "2"
 tauri-plugin-notification = "2"
+tauri-plugin-process = "2"
 tauri-plugin-shell = "2"
+tauri-plugin-updater = "2"
 rdev = "0.5"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -2,10 +2,12 @@
   "$schema": "../gen/schemas/desktop-schema.json",
   "identifier": "default",
   "description": "Default app capabilities",
-  "windows": ["main", "status-bar"],
+  "windows": ["main", "status-bar", "update-toast"],
   "permissions": [
     "core:default",
     "shell:allow-open",
-    "notification:default"
+    "notification:default",
+    "updater:default",
+    "process:default"
   ]
 }

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -136,6 +136,34 @@ pub fn show_pill(app: tauri::AppHandle) -> Result<(), String> {
     Ok(())
 }
 
+/// Dismiss the update-toast speech bubble. Called when the user clicks
+/// "Später" or after the auto-dismiss timeout.
+#[tauri::command]
+pub fn dismiss_update_toast(app: tauri::AppHandle) -> Result<(), String> {
+    if let Some(toast) = app.get_webview_window("update-toast") {
+        toast.hide().map_err(|e| e.to_string())?;
+    }
+    Ok(())
+}
+
+/// User clicked "Update?" on the speech bubble. Hide the toast, surface
+/// the main window, and tell the frontend to switch to the About page so
+/// the user can see the full update flow there.
+#[tauri::command]
+pub fn accept_update_toast(app: tauri::AppHandle) -> Result<(), String> {
+    if let Some(toast) = app.get_webview_window("update-toast") {
+        let _ = toast.hide();
+    }
+    if let Some(main) = app.get_webview_window("main") {
+        let _ = main.unminimize();
+        let _ = main.show();
+        let _ = main.set_focus();
+        main.emit("updater://navigate-to-about", ())
+            .map_err(|e| e.to_string())?;
+    }
+    Ok(())
+}
+
 #[tauri::command]
 pub fn get_model_status(app: tauri::AppHandle, size: String) -> Result<ModelStatus, String> {
     let path = model_path(&app, &size)?;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -19,7 +19,7 @@ use tauri::{
     image::Image,
     menu::{Menu, MenuItem},
     tray::TrayIconBuilder,
-    Manager, WindowEvent,
+    Emitter, Manager, WindowEvent,
 };
 
 use audio::{AudioBuffer, AudioRecordingState};
@@ -88,6 +88,8 @@ pub fn run() {
         .plugin(tauri_plugin_shell::init())
         .plugin(tauri_plugin_notification::init())
         .plugin(tauri_plugin_autostart::init(tauri_plugin_autostart::MacosLauncher::LaunchAgent, None))
+        .plugin(tauri_plugin_process::init())
+        .plugin(tauri_plugin_updater::Builder::new().build())
         .manage(AppStateManager(Mutex::new(AppState::Idle)))
         .manage(AudioRecordingState::new())
         .manage(AudioBuffer(Mutex::new(None)))
@@ -183,6 +185,34 @@ pub fn run() {
                 });
             }
 
+            if let Some(toast) = app.get_webview_window("update-toast") {
+                // The toast stays hidden in tauri.conf.json (`visible: false`).
+                // Position is set lazily in `show_update_toast` based on the
+                // pill's current monitor. Always-on-top is asserted here since
+                // the config flag is non-persistent across hide/show on
+                // Windows, same caveat as the pill.
+                let _ = toast.set_always_on_top(true);
+            }
+
+            // Optional auto-update check on launch. Default OFF — opt-in via
+            // Settings → Privacy → "Check for updates automatically". Skipped
+            // during onboarding because the feature surface isn't reachable
+            // yet anyway. Delayed by 5s so the boot path stays responsive.
+            let auto_check_enabled = {
+                let handle = app.handle();
+                let settings = crate::storage::load(handle).unwrap_or_default();
+                settings["privacy"]["autoCheckUpdates"]
+                    .as_bool()
+                    .unwrap_or(false)
+            };
+            if onboarding_done && auto_check_enabled {
+                let app_handle = app.handle().clone();
+                tauri::async_runtime::spawn(async move {
+                    tokio::time::sleep(std::time::Duration::from_secs(5)).await;
+                    check_for_updates_silently(app_handle).await;
+                });
+            }
+
             if let Some(main) = app.get_webview_window("main") {
                 // Use small icon for title bar — avoids Windows scaling artefacts
                 if let Ok(icon) = tauri::image::Image::from_bytes(
@@ -253,6 +283,8 @@ pub fn run() {
             commands::set_audio_device,
             commands::unlock_recording,
             commands::show_pill,
+            commands::dismiss_update_toast,
+            commands::accept_update_toast,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");
@@ -306,9 +338,100 @@ async fn watch_active_monitor(app: tauri::AppHandle, initial_monitor_name: Optio
         let name = monitor.name().cloned();
         if name != last_name {
             position_status_bar(&status_bar, monitor);
+            // If the toast is currently visible, keep it pinned to the same
+            // active monitor. We don't re-position when hidden because the
+            // next `show_update_toast` call repositions on its own.
+            if let Some(toast) = app.get_webview_window("update-toast") {
+                if toast.is_visible().unwrap_or(false) {
+                    position_update_toast(&toast, monitor);
+                }
+            }
             last_name = name;
         }
     }
+}
+
+/// Position the update-toast window above the pill on the given monitor,
+/// horizontally centred over the pill. Pill anchor math mirrors the
+/// `position_status_bar` formula so the two stay aligned.
+pub fn position_update_toast(window: &tauri::WebviewWindow, monitor: &tauri::Monitor) {
+    let scale = monitor.scale_factor();
+    let size = monitor.size();
+    let origin = monitor.position();
+    let pill_w = (380.0 * scale) as i32;
+    let pill_h = (72.0 * scale) as i32;
+    let toast_w = (320.0 * scale) as i32;
+    let toast_h = (96.0 * scale) as i32;
+    let gap = (12.0 * scale) as i32;
+    let pill_x = origin.x + (size.width as i32 - pill_w) / 2;
+    let pill_y = origin.y + size.height as i32 - pill_h - (56.0 * scale) as i32;
+    let x = pill_x + (pill_w - toast_w) / 2;
+    let y = pill_y - toast_h - gap;
+    let _ = window.set_position(tauri::PhysicalPosition::new(x, y));
+}
+
+/// Background auto-check entry point. Emits `updater://update-available`
+/// to all windows when a new version is found and conditionally shows
+/// the pill speech bubble (only when the user is not actively recording —
+/// the about-nav-item dot still surfaces via the broadcast event).
+async fn check_for_updates_silently(app: tauri::AppHandle) {
+    use tauri_plugin_updater::UpdaterExt;
+    let updater = match app.updater() {
+        Ok(u) => u,
+        Err(e) => {
+            log::warn!("auto-update: failed to get updater: {}", e);
+            return;
+        }
+    };
+    match updater.check().await {
+        Ok(Some(update)) => {
+            let payload = serde_json::json!({
+                "version": update.version,
+                "notes": update.body,
+            });
+            let _ = app.emit("updater://update-available", payload);
+            let is_idle = matches!(
+                *app.state::<AppStateManager>().0.lock().unwrap(),
+                AppState::Idle
+            );
+            if is_idle {
+                show_update_toast(&app, &update.version, update.body.as_deref());
+            }
+        }
+        Ok(None) => {}
+        Err(e) => {
+            log::warn!("auto-update check failed: {}", e);
+        }
+    }
+}
+
+/// Render the speech-bubble notification above the pill. Re-positions to
+/// the active monitor each time it is shown.
+pub fn show_update_toast(app: &tauri::AppHandle, version: &str, notes: Option<&str>) {
+    let Some(toast) = app.get_webview_window("update-toast") else {
+        return;
+    };
+    let monitors = toast.available_monitors().unwrap_or_default();
+    let cursor_monitor = app
+        .cursor_position()
+        .ok()
+        .and_then(|c| monitor_for_cursor(&monitors, c))
+        .and_then(|i| monitors.get(i).cloned());
+    let monitor = cursor_monitor
+        .or_else(|| toast.primary_monitor().ok().flatten())
+        .or_else(|| toast.current_monitor().ok().flatten());
+    if let Some(m) = &monitor {
+        position_update_toast(&toast, m);
+    }
+    let payload = serde_json::json!({
+        "version": version,
+        "notes": notes,
+    });
+    let _ = toast.emit("update-toast://show", payload);
+    let _ = toast.show();
+    // Deliberately not calling set_focus — the toast is a notification,
+    // not a workflow interruption. The user keeps focus on whatever they
+    // were doing and clicks the toast only if they want to act.
 }
 
 pub fn update_tray_icon(app: &tauri::AppHandle, state: &AppState) {

--- a/src-tauri/src/storage/mod.rs
+++ b/src-tauri/src/storage/mod.rs
@@ -515,7 +515,8 @@ pub(crate) fn defaults() -> serde_json::Value {
         },
         "privacy": {
             "historyTracking": true,
-            "targetAppTracking": false
+            "targetAppTracking": false,
+            "autoCheckUpdates": false
         }
     })
 }
@@ -644,6 +645,22 @@ mod tests {
         let d = defaults();
         assert_eq!(d["privacy"]["historyTracking"], true);
         assert_eq!(d["privacy"]["targetAppTracking"], false);
+    }
+
+    #[test]
+    fn defaults_auto_check_updates_is_off() {
+        // Opt-in only — outbound network call to GitHub on launch should
+        // not happen without explicit user consent.
+        assert_eq!(defaults()["privacy"]["autoCheckUpdates"], false);
+    }
+
+    #[test]
+    fn merge_fills_missing_auto_check_updates_with_false() {
+        let loaded = serde_json::json!({
+            "privacy": { "historyTracking": true, "targetAppTracking": false }
+        });
+        let merged = merge_defaults(loaded, defaults());
+        assert_eq!(merged["privacy"]["autoCheckUpdates"], false);
     }
 
     // ── merge_defaults ────────────────────────────────────────────────────────

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -40,8 +40,30 @@
         "alwaysOnTop": true,
         "skipTaskbar": true,
         "transparent": true
+      },
+      {
+        "label": "update-toast",
+        "title": "",
+        "width": 320,
+        "height": 96,
+        "resizable": false,
+        "fullscreen": false,
+        "visible": false,
+        "decorations": false,
+        "shadow": false,
+        "alwaysOnTop": true,
+        "skipTaskbar": true,
+        "transparent": true
       }
     ]
+  },
+  "plugins": {
+    "updater": {
+      "endpoints": [
+        "https://github.com/fnnbl/voca-app/releases/latest/download/latest.json"
+      ],
+      "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDg4MEYxNDU5N0FBQzMyRDcKUldUWE1xeDZXUlFQaU9XWFVpSndyR0JTY3AvN2JURU1WL29LR0phMDlXanVyQkJXUk5UZHNFdFMK"
+    }
   },
   "bundle": {
     "active": true,

--- a/src/UpdateToast.tsx
+++ b/src/UpdateToast.tsx
@@ -1,0 +1,61 @@
+import { useEffect, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { invoke } from '@tauri-apps/api/core'
+import { listen } from '@tauri-apps/api/event'
+
+interface ShowPayload {
+  version: string
+  notes: string | null
+}
+
+const AUTO_DISMISS_MS = 10_000
+
+export default function UpdateToast() {
+  const { t } = useTranslation()
+  const [version, setVersion] = useState<string | null>(null)
+
+  useEffect(() => {
+    const unlisten = listen<ShowPayload>('update-toast://show', (event) => {
+      setVersion(event.payload.version)
+    })
+    return () => {
+      void unlisten.then((fn) => fn())
+    }
+  }, [])
+
+  useEffect(() => {
+    if (!version) return
+    const handle = window.setTimeout(() => {
+      void invoke('dismiss_update_toast').catch(console.error)
+    }, AUTO_DISMISS_MS)
+    return () => window.clearTimeout(handle)
+  }, [version])
+
+  function handleAccept() {
+    void invoke('accept_update_toast').catch(console.error)
+  }
+
+  function handleDismiss() {
+    void invoke('dismiss_update_toast').catch(console.error)
+  }
+
+  if (!version) return null
+
+  return (
+    <div className="toast-frame">
+      <div className="toast-bubble">
+        <div className="toast-greeting">{t('toast.update.greeting')}</div>
+        <div className="toast-body">{t('toast.update.body', { version })}</div>
+        <div className="toast-actions">
+          <button type="button" className="toast-btn toast-btn-primary" onClick={handleAccept}>
+            {t('toast.update.update')}
+          </button>
+          <button type="button" className="toast-btn toast-btn-ghost" onClick={handleDismiss}>
+            {t('toast.update.later')}
+          </button>
+        </div>
+      </div>
+      <div className="toast-tail" aria-hidden="true" />
+    </div>
+  )
+}

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -188,7 +188,22 @@
     "about": {
       "bmc": "Buy me a coffee",
       "credits": "Gebaut mit Tauri, React und whisper.cpp.",
-      "legalLinks": "Rechtliches"
+      "legalLinks": "Rechtliches",
+      "updates": {
+        "checkButton": "Nach Updates suchen",
+        "checking": "Suche nach Updates…",
+        "upToDate": "Du bist auf der aktuellen Version.",
+        "checkAgain": "Erneut prüfen",
+        "available": "Update verfügbar: v{{version}}",
+        "updateNow": "Jetzt aktualisieren",
+        "later": "Später",
+        "downloading": "Lädt herunter… {{pct}} %",
+        "downloadingNoSize": "Update wird geladen…",
+        "ready": "Update bereit. VOCA startet neu.",
+        "restart": "Jetzt neu starten",
+        "error": "Updates konnten nicht abgerufen werden.",
+        "retry": "Erneut versuchen"
+      }
     },
     "legal": {
       "privacy": "Datenschutz",
@@ -212,7 +227,9 @@
       "historyTracking": "Verlauf speichern",
       "historyTrackingDesc": "Transkripte werden lokal gespeichert und in History und Stats angezeigt.",
       "targetAppTracking": "Ziel-App erfassen",
-      "targetAppTrackingDesc": "Merkt sich, in welche App du einfügst – nur für die \"Häufigstes Ziel\"-Statistik. Bleibt lokal."
+      "targetAppTrackingDesc": "Merkt sich, in welche App du einfügst – nur für die \"Häufigstes Ziel\"-Statistik. Bleibt lokal.",
+      "autoCheckUpdates": "Updates automatisch prüfen",
+      "autoCheckUpdatesDesc": "VOCA fragt einmal täglich GitHub nach Updates. Es werden keine persönlichen Daten gesendet."
     },
     "transcription": {
       "method": "Methode",
@@ -320,5 +337,13 @@
     "add": "Hinzufügen",
     "close": "Schließen",
     "retry": "Erneut prüfen"
+  },
+  "toast": {
+    "update": {
+      "greeting": "Hey.",
+      "body": "Update verfügbar: v{{version}}",
+      "update": "Update?",
+      "later": "Später"
+    }
   }
 }

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -188,7 +188,22 @@
     "about": {
       "bmc": "Buy me a coffee",
       "credits": "Built with Tauri, React, and whisper.cpp.",
-      "legalLinks": "Legal"
+      "legalLinks": "Legal",
+      "updates": {
+        "checkButton": "Check for updates",
+        "checking": "Checking for updates…",
+        "upToDate": "You're on the latest version.",
+        "checkAgain": "Check again",
+        "available": "Update available: v{{version}}",
+        "updateNow": "Update now",
+        "later": "Later",
+        "downloading": "Downloading… {{pct}}%",
+        "downloadingNoSize": "Downloading update…",
+        "ready": "Update ready. VOCA will restart.",
+        "restart": "Restart now",
+        "error": "Couldn't check for updates.",
+        "retry": "Retry"
+      }
     },
     "legal": {
       "privacy": "Privacy",
@@ -212,7 +227,9 @@
       "historyTracking": "Keep transcript history",
       "historyTrackingDesc": "Transcripts are stored locally and shown in History and Stats.",
       "targetAppTracking": "Record target app",
-      "targetAppTrackingDesc": "Remembers which app you paste into — used only for the \"Most common target\" stat. Stays local."
+      "targetAppTrackingDesc": "Remembers which app you paste into — used only for the \"Most common target\" stat. Stays local.",
+      "autoCheckUpdates": "Check for updates automatically",
+      "autoCheckUpdatesDesc": "VOCA quietly checks GitHub once a day. No personal data is sent."
     },
     "transcription": {
       "method": "Method",
@@ -320,5 +337,13 @@
     "add": "Add",
     "close": "Close",
     "retry": "Retry"
+  },
+  "toast": {
+    "update": {
+      "greeting": "Hey.",
+      "body": "Update available: v{{version}}",
+      "update": "Update?",
+      "later": "Later"
+    }
   }
 }

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -188,7 +188,22 @@
     "about": {
       "bmc": "Buy me a coffee",
       "credits": "Hecho con Tauri, React y whisper.cpp.",
-      "legalLinks": "Legal"
+      "legalLinks": "Legal",
+      "updates": {
+        "checkButton": "Buscar actualizaciones",
+        "checking": "Buscando actualizaciones…",
+        "upToDate": "Estás en la versión más reciente.",
+        "checkAgain": "Volver a comprobar",
+        "available": "Actualización disponible: v{{version}}",
+        "updateNow": "Actualizar ahora",
+        "later": "Después",
+        "downloading": "Descargando… {{pct}} %",
+        "downloadingNoSize": "Descargando actualización…",
+        "ready": "Actualización lista. VOCA se reiniciará.",
+        "restart": "Reiniciar ahora",
+        "error": "No se pudo buscar actualizaciones.",
+        "retry": "Reintentar"
+      }
     },
     "legal": {
       "privacy": "Privacidad",
@@ -212,7 +227,9 @@
       "historyTracking": "Guardar historial",
       "historyTrackingDesc": "Las transcripciones se guardan en local y se muestran en Historial y Estadísticas.",
       "targetAppTracking": "Registrar app destino",
-      "targetAppTrackingDesc": "Recuerda en qué app pegas el texto — solo para la estadística \"App más frecuente\". Se queda en local."
+      "targetAppTrackingDesc": "Recuerda en qué app pegas el texto — solo para la estadística \"App más frecuente\". Se queda en local.",
+      "autoCheckUpdates": "Buscar actualizaciones automáticamente",
+      "autoCheckUpdatesDesc": "VOCA consulta GitHub una vez al día. No se envían datos personales."
     },
     "transcription": {
       "method": "Método",
@@ -320,5 +337,13 @@
     "add": "Añadir",
     "close": "Cerrar",
     "retry": "Reintentar"
+  },
+  "toast": {
+    "update": {
+      "greeting": "Hola.",
+      "body": "Actualización disponible: v{{version}}",
+      "update": "¿Actualizar?",
+      "later": "Después"
+    }
   }
 }

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -188,7 +188,22 @@
     "about": {
       "bmc": "Buy me a coffee",
       "credits": "Construit avec Tauri, React et whisper.cpp.",
-      "legalLinks": "Mentions légales"
+      "legalLinks": "Mentions légales",
+      "updates": {
+        "checkButton": "Rechercher des mises à jour",
+        "checking": "Recherche de mises à jour…",
+        "upToDate": "Vous êtes sur la dernière version.",
+        "checkAgain": "Vérifier à nouveau",
+        "available": "Mise à jour disponible : v{{version}}",
+        "updateNow": "Mettre à jour maintenant",
+        "later": "Plus tard",
+        "downloading": "Téléchargement… {{pct}} %",
+        "downloadingNoSize": "Téléchargement de la mise à jour…",
+        "ready": "Mise à jour prête. VOCA va redémarrer.",
+        "restart": "Redémarrer maintenant",
+        "error": "Impossible de rechercher des mises à jour.",
+        "retry": "Réessayer"
+      }
     },
     "legal": {
       "privacy": "Confidentialité",
@@ -212,7 +227,9 @@
       "historyTracking": "Conserver l'historique",
       "historyTrackingDesc": "Les transcriptions sont stockées localement et affichées dans Historique et Stats.",
       "targetAppTracking": "Enregistrer l'app cible",
-      "targetAppTrackingDesc": "Mémorise dans quelle app tu colles le texte — uniquement pour la stat \"App la plus fréquente\". Reste en local."
+      "targetAppTrackingDesc": "Mémorise dans quelle app tu colles le texte — uniquement pour la stat \"App la plus fréquente\". Reste en local.",
+      "autoCheckUpdates": "Vérifier les mises à jour automatiquement",
+      "autoCheckUpdatesDesc": "VOCA interroge GitHub une fois par jour. Aucune donnée personnelle n'est envoyée."
     },
     "transcription": {
       "method": "Méthode",
@@ -320,5 +337,13 @@
     "add": "Ajouter",
     "close": "Fermer",
     "retry": "Réessayer"
+  },
+  "toast": {
+    "update": {
+      "greeting": "Salut.",
+      "body": "Mise à jour disponible : v{{version}}",
+      "update": "Mettre à jour ?",
+      "later": "Plus tard"
+    }
   }
 }

--- a/src/i18n/locales/it.json
+++ b/src/i18n/locales/it.json
@@ -188,7 +188,22 @@
     "about": {
       "bmc": "Buy me a coffee",
       "credits": "Realizzato con Tauri, React e whisper.cpp.",
-      "legalLinks": "Note legali"
+      "legalLinks": "Note legali",
+      "updates": {
+        "checkButton": "Cerca aggiornamenti",
+        "checking": "Ricerca aggiornamenti…",
+        "upToDate": "Sei sulla versione più recente.",
+        "checkAgain": "Cerca di nuovo",
+        "available": "Aggiornamento disponibile: v{{version}}",
+        "updateNow": "Aggiorna ora",
+        "later": "Più tardi",
+        "downloading": "Download… {{pct}} %",
+        "downloadingNoSize": "Download dell'aggiornamento…",
+        "ready": "Aggiornamento pronto. VOCA si riavvierà.",
+        "restart": "Riavvia ora",
+        "error": "Impossibile cercare aggiornamenti.",
+        "retry": "Riprova"
+      }
     },
     "legal": {
       "privacy": "Privacy",
@@ -212,7 +227,9 @@
       "historyTracking": "Conserva la cronologia",
       "historyTrackingDesc": "Le trascrizioni vengono salvate localmente e mostrate in Cronologia e Statistiche.",
       "targetAppTracking": "Registra l'app di destinazione",
-      "targetAppTrackingDesc": "Memorizza in quale app incolli — solo per la statistica \"App più frequente\". Resta in locale."
+      "targetAppTrackingDesc": "Memorizza in quale app incolli — solo per la statistica \"App più frequente\". Resta in locale.",
+      "autoCheckUpdates": "Controlla aggiornamenti automaticamente",
+      "autoCheckUpdatesDesc": "VOCA chiede a GitHub una volta al giorno. Nessun dato personale viene inviato."
     },
     "transcription": {
       "method": "Metodo",
@@ -320,5 +337,13 @@
     "add": "Aggiungi",
     "close": "Chiudi",
     "retry": "Riprova"
+  },
+  "toast": {
+    "update": {
+      "greeting": "Ehi.",
+      "body": "Aggiornamento disponibile: v{{version}}",
+      "update": "Aggiornare?",
+      "later": "Più tardi"
+    }
   }
 }

--- a/src/i18n/locales/pt.json
+++ b/src/i18n/locales/pt.json
@@ -188,7 +188,22 @@
     "about": {
       "bmc": "Buy me a coffee",
       "credits": "Construído com Tauri, React e whisper.cpp.",
-      "legalLinks": "Legal"
+      "legalLinks": "Legal",
+      "updates": {
+        "checkButton": "Procurar atualizações",
+        "checking": "A procurar atualizações…",
+        "upToDate": "Estás na versão mais recente.",
+        "checkAgain": "Procurar novamente",
+        "available": "Atualização disponível: v{{version}}",
+        "updateNow": "Atualizar agora",
+        "later": "Depois",
+        "downloading": "A transferir… {{pct}} %",
+        "downloadingNoSize": "A transferir atualização…",
+        "ready": "Atualização pronta. O VOCA vai reiniciar.",
+        "restart": "Reiniciar agora",
+        "error": "Não foi possível procurar atualizações.",
+        "retry": "Tentar novamente"
+      }
     },
     "legal": {
       "privacy": "Privacidade",
@@ -212,7 +227,9 @@
       "historyTracking": "Guardar histórico",
       "historyTrackingDesc": "As transcrições são guardadas localmente e mostradas em Histórico e Stats.",
       "targetAppTracking": "Registar app de destino",
-      "targetAppTrackingDesc": "Lembra em que app colas o texto — só para a estatística \"App mais frequente\". Fica em local."
+      "targetAppTrackingDesc": "Lembra em que app colas o texto — só para a estatística \"App mais frequente\". Fica em local.",
+      "autoCheckUpdates": "Procurar atualizações automaticamente",
+      "autoCheckUpdatesDesc": "O VOCA consulta o GitHub uma vez por dia. Não são enviados dados pessoais."
     },
     "transcription": {
       "method": "Método",
@@ -320,5 +337,13 @@
     "add": "Adicionar",
     "close": "Fechar",
     "retry": "Tentar novamente"
+  },
+  "toast": {
+    "update": {
+      "greeting": "Olá.",
+      "body": "Atualização disponível: v{{version}}",
+      "update": "Atualizar?",
+      "later": "Depois"
+    }
   }
 }

--- a/src/index.css
+++ b/src/index.css
@@ -589,3 +589,158 @@ input[type="password"]::-ms-reveal { display: none; }
   border: 0;
 }
 .btn-primary:hover { background: var(--v-ink-2); }
+
+/* ============================================================
+   Update toast (speech bubble above the pill)
+   ============================================================ */
+.toast-frame {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: flex-start;
+  pointer-events: none;
+  padding-top: 4px;
+}
+.toast-bubble {
+  width: 304px;
+  background: var(--v-ink);
+  color: var(--v-bg);
+  border-radius: 18px;
+  padding: 10px 14px 12px;
+  box-shadow: 0 8px 24px rgba(0,0,0,0.28), 0 0 0 0.5px rgba(255,255,255,0.08);
+  pointer-events: auto;
+  font-family: var(--f-ui);
+}
+.toast-greeting {
+  font-family: var(--f-display);
+  font-weight: 700;
+  font-size: 13px;
+  letter-spacing: 0.02em;
+  margin-bottom: 1px;
+}
+.toast-body {
+  font-size: 12px;
+  color: rgba(255,255,255,0.78);
+  margin-bottom: 8px;
+  line-height: 1.35;
+}
+.toast-actions {
+  display: flex;
+  gap: 8px;
+}
+.toast-btn {
+  flex: 1;
+  border: 0;
+  padding: 5px 10px;
+  font-family: var(--f-ui);
+  font-size: 12px;
+  font-weight: 500;
+  border-radius: 999px;
+  cursor: pointer;
+  transition: background var(--dur-1) var(--ease);
+}
+.toast-btn-primary {
+  background: var(--v-bg);
+  color: var(--v-ink);
+}
+.toast-btn-primary:hover {
+  background: rgba(255,255,255,0.88);
+}
+.toast-btn-ghost {
+  background: transparent;
+  color: rgba(255,255,255,0.7);
+}
+.toast-btn-ghost:hover {
+  background: rgba(255,255,255,0.08);
+  color: var(--v-bg);
+}
+.toast-tail {
+  width: 0;
+  height: 0;
+  border-left: 8px solid transparent;
+  border-right: 8px solid transparent;
+  border-top: 9px solid var(--v-ink);
+  margin-top: -1px;
+  filter: drop-shadow(0 4px 4px rgba(0,0,0,0.18));
+}
+
+/* ============================================================
+   Nav-item update dot + About-page update panel
+   ============================================================ */
+.shell-nav-item .nav-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--v-ember);
+  margin-left: auto;
+  flex-shrink: 0;
+}
+.about-updates {
+  margin: 16px 0 24px;
+  padding: 12px 16px;
+  background: var(--v-surface);
+  border: 1px solid var(--v-line-soft);
+  border-radius: var(--r-2);
+}
+.about-update-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  font-size: 13px;
+  color: var(--v-ink);
+}
+.about-update-row.column {
+  flex-direction: column;
+  align-items: stretch;
+  gap: 8px;
+}
+.about-update-row.error {
+  color: var(--v-danger);
+}
+.about-update-row .muted {
+  color: var(--v-ink-3);
+}
+.about-update-actions {
+  display: flex;
+  gap: 8px;
+}
+.about-update-btn {
+  border: 0;
+  padding: 5px 12px;
+  border-radius: 999px;
+  font-family: var(--f-ui);
+  font-size: 12px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: background var(--dur-1) var(--ease);
+}
+.about-update-btn.primary {
+  background: var(--v-ink);
+  color: var(--v-bg);
+}
+.about-update-btn.primary:hover {
+  background: var(--v-ink-2);
+}
+.about-update-btn.ghost {
+  background: transparent;
+  color: var(--v-ink-3);
+}
+.about-update-btn.ghost:hover {
+  background: var(--v-accent-soft);
+  color: var(--v-ink);
+}
+.about-update-link {
+  border: 0;
+  background: transparent;
+  color: var(--v-ink-3);
+  font-size: 12px;
+  text-decoration: underline;
+  cursor: pointer;
+  padding: 0;
+}
+.about-update-link:hover {
+  color: var(--v-ink);
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -5,16 +5,23 @@ import './i18n'
 import './index.css'
 import App from './App'
 import StatusBar from './StatusBar'
+import UpdateToast from './UpdateToast'
 
 const label = getCurrentWebviewWindow().label
+const isPill = label === 'status-bar'
+const isToast = label === 'update-toast'
 
-if (label === 'status-bar') {
+if (isPill || isToast) {
   document.documentElement.style.background = 'transparent'
   document.body.style.background = 'transparent'
 }
 
+function rootView() {
+  if (isPill) return <StatusBar />
+  if (isToast) return <UpdateToast />
+  return <App />
+}
+
 ReactDOM.createRoot(document.getElementById('root')!).render(
-  <React.StrictMode>
-    {label === 'status-bar' ? <StatusBar /> : <App />}
-  </React.StrictMode>
+  <React.StrictMode>{rootView()}</React.StrictMode>
 )

--- a/src/pages/AboutPage.tsx
+++ b/src/pages/AboutPage.tsx
@@ -1,5 +1,9 @@
+import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { open } from '@tauri-apps/plugin-shell'
+import { check, type Update } from '@tauri-apps/plugin-updater'
+import { relaunch } from '@tauri-apps/plugin-process'
+import { useAppStore } from '../stores/appStore'
 import { version as appVersion } from '../../package.json'
 
 const BMC_URL = 'https://buymeacoffee.com/fnnbl'
@@ -8,8 +12,81 @@ interface Props {
   onOpenLegal?: (tab: 'privacy' | 'terms') => void
 }
 
+type UpdaterState =
+  | { kind: 'idle' }
+  | { kind: 'checking' }
+  | { kind: 'upToDate' }
+  | { kind: 'updateAvailable'; version: string }
+  | { kind: 'downloading'; received: number; total: number | null }
+  | { kind: 'readyToInstall' }
+  | { kind: 'error'; message: string }
+
 export function AboutPage({ onOpenLegal }: Props) {
   const { t } = useTranslation()
+  const updateInfo = useAppStore((s) => s.updateAvailable)
+  const setUpdateAvailable = useAppStore((s) => s.setUpdateAvailable)
+  const [state, setState] = useState<UpdaterState>({ kind: 'idle' })
+  const [updateObj, setUpdateObj] = useState<Update | null>(null)
+
+  async function performCheck() {
+    setState({ kind: 'checking' })
+    try {
+      const update = await check()
+      if (!update) {
+        setState({ kind: 'upToDate' })
+        setUpdateAvailable(null)
+        setUpdateObj(null)
+        return
+      }
+      setUpdateObj(update)
+      setUpdateAvailable({ version: update.version, notes: update.body ?? null })
+      setState({ kind: 'updateAvailable', version: update.version })
+    } catch (e) {
+      setState({ kind: 'error', message: String(e) })
+    }
+  }
+
+  async function performInstall() {
+    let upd = updateObj
+    if (!upd) {
+      try {
+        const fetched = await check()
+        if (!fetched) {
+          setState({ kind: 'upToDate' })
+          setUpdateAvailable(null)
+          return
+        }
+        upd = fetched
+        setUpdateObj(fetched)
+      } catch (e) {
+        setState({ kind: 'error', message: String(e) })
+        return
+      }
+    }
+    setState({ kind: 'downloading', received: 0, total: null })
+    try {
+      let total: number | null = null
+      let received = 0
+      await upd.downloadAndInstall((event) => {
+        if (event.event === 'Started') {
+          total = event.data.contentLength ?? null
+          setState({ kind: 'downloading', received: 0, total })
+        } else if (event.event === 'Progress') {
+          received += event.data.chunkLength
+          setState({ kind: 'downloading', received, total })
+        } else if (event.event === 'Finished') {
+          setState({ kind: 'readyToInstall' })
+        }
+      })
+      setState({ kind: 'readyToInstall' })
+    } catch (e) {
+      setState({ kind: 'error', message: String(e) })
+    }
+  }
+
+  function dismissAndIdle() {
+    setState({ kind: 'idle' })
+  }
 
   return (
     <div className="about-page">
@@ -31,6 +108,18 @@ export function AboutPage({ onOpenLegal }: Props) {
       <p className="about-meta">
         VOCA v{appVersion} · open source · MIT License
       </p>
+
+      <div className="about-updates">
+        <UpdaterPanel
+          state={state}
+          preStagedUpdate={state.kind === 'idle' ? updateInfo : null}
+          onCheck={performCheck}
+          onInstall={performInstall}
+          onLater={dismissAndIdle}
+          onRestart={() => void relaunch()}
+          onRetry={dismissAndIdle}
+        />
+      </div>
 
       <button
         type="button"
@@ -58,6 +147,119 @@ export function AboutPage({ onOpenLegal }: Props) {
           </button>
         </nav>
       )}
+    </div>
+  )
+}
+
+interface PanelProps {
+  state: UpdaterState
+  preStagedUpdate: { version: string; notes: string | null } | null
+  onCheck: () => void
+  onInstall: () => void
+  onLater: () => void
+  onRestart: () => void
+  onRetry: () => void
+}
+
+function UpdaterPanel({
+  state,
+  preStagedUpdate,
+  onCheck,
+  onInstall,
+  onLater,
+  onRestart,
+  onRetry,
+}: PanelProps) {
+  const { t } = useTranslation()
+
+  if (state.kind === 'checking') {
+    return <div className="about-update-row muted">{t('settings.about.updates.checking')}</div>
+  }
+  if (state.kind === 'upToDate') {
+    return (
+      <div className="about-update-row">
+        <span className="muted">{t('settings.about.updates.upToDate')}</span>
+        <button type="button" className="about-update-link" onClick={onCheck}>
+          {t('settings.about.updates.checkAgain')}
+        </button>
+      </div>
+    )
+  }
+  if (state.kind === 'updateAvailable') {
+    return (
+      <div className="about-update-row">
+        <span>{t('settings.about.updates.available', { version: state.version })}</span>
+        <div className="about-update-actions">
+          <button type="button" className="about-update-btn primary" onClick={onInstall}>
+            {t('settings.about.updates.updateNow')}
+          </button>
+          <button type="button" className="about-update-btn ghost" onClick={onLater}>
+            {t('settings.about.updates.later')}
+          </button>
+        </div>
+      </div>
+    )
+  }
+  if (state.kind === 'downloading') {
+    const pct =
+      state.total != null && state.total > 0
+        ? Math.min(100, Math.round((state.received / state.total) * 100))
+        : null
+    return (
+      <div className="about-update-row column">
+        <span className="muted">
+          {pct != null
+            ? t('settings.about.updates.downloading', { pct })
+            : t('settings.about.updates.downloadingNoSize')}
+        </span>
+        <div className="pbar-wrap" style={{ width: '100%' }}>
+          <span className="pbar-fill" style={{ width: `${pct ?? 30}%` }} />
+        </div>
+      </div>
+    )
+  }
+  if (state.kind === 'readyToInstall') {
+    return (
+      <div className="about-update-row">
+        <span>{t('settings.about.updates.ready')}</span>
+        <button type="button" className="about-update-btn primary" onClick={onRestart}>
+          {t('settings.about.updates.restart')}
+        </button>
+      </div>
+    )
+  }
+  if (state.kind === 'error') {
+    return (
+      <div className="about-update-row error">
+        <span>{t('settings.about.updates.error')}</span>
+        <button type="button" className="about-update-link" onClick={onRetry}>
+          {t('settings.about.updates.retry')}
+        </button>
+      </div>
+    )
+  }
+
+  // idle
+  if (preStagedUpdate) {
+    return (
+      <div className="about-update-row">
+        <span>{t('settings.about.updates.available', { version: preStagedUpdate.version })}</span>
+        <div className="about-update-actions">
+          <button type="button" className="about-update-btn primary" onClick={onInstall}>
+            {t('settings.about.updates.updateNow')}
+          </button>
+          <button type="button" className="about-update-btn ghost" onClick={onLater}>
+            {t('settings.about.updates.later')}
+          </button>
+        </div>
+      </div>
+    )
+  }
+  return (
+    <div className="about-update-row">
+      <button type="button" className="about-update-btn primary" onClick={onCheck}>
+        {t('settings.about.updates.checkButton')}
+      </button>
     </div>
   )
 }

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -1,5 +1,6 @@
-import { useState, type ReactNode } from 'react'
+import { useEffect, useState, type ReactNode } from 'react'
 import { useTranslation } from 'react-i18next'
+import { listen } from '@tauri-apps/api/event'
 import { useAppStore } from '../stores/appStore'
 import { GeneralSettings } from './settings/GeneralSettings'
 import { TranscriptionSettings } from './settings/TranscriptionSettings'
@@ -28,6 +29,27 @@ export function SettingsPage({ settings, onSave }: Props) {
   const [active, setActive] = useState<NavId>('history')
   const [legalTab, setLegalTab] = useState<LegalTab>('privacy')
   const error = useAppStore((s) => s.error)
+  const updateAvailable = useAppStore((s) => s.updateAvailable)
+  const setUpdateAvailable = useAppStore((s) => s.setUpdateAvailable)
+
+  useEffect(() => {
+    const unlistenAvailable = listen<{ version: string; notes: string | null }>(
+      'updater://update-available',
+      (event) => {
+        setUpdateAvailable({
+          version: event.payload.version,
+          notes: event.payload.notes ?? null,
+        })
+      },
+    )
+    const unlistenNavigate = listen('updater://navigate-to-about', () => {
+      setActive('about')
+    })
+    return () => {
+      void unlistenAvailable.then((fn) => fn())
+      void unlistenNavigate.then((fn) => fn())
+    }
+  }, [setUpdateAvailable])
 
   function openLegal(tab: LegalTab) {
     setLegalTab(tab)
@@ -80,7 +102,14 @@ export function SettingsPage({ settings, onSave }: Props) {
           <NavItem id="general" active={active} onClick={setActive} icon={<SettingsIcon />}>
             {t('settings.nav.general')}
           </NavItem>
-          <NavItem id="about" active={active} onClick={setActive} icon={<InfoIcon />} variant="bottom">
+          <NavItem
+            id="about"
+            active={active}
+            onClick={setActive}
+            icon={<InfoIcon />}
+            variant="bottom"
+            hasDot={!!updateAvailable}
+          >
             {t('settings.nav.about', 'About')}
           </NavItem>
         </nav>
@@ -116,7 +145,7 @@ export function SettingsPage({ settings, onSave }: Props) {
 }
 
 function NavItem({
-  id, active, onClick, icon, kbd, children, variant,
+  id, active, onClick, icon, kbd, children, variant, hasDot,
 }: {
   id: NavId
   active: NavId
@@ -125,6 +154,7 @@ function NavItem({
   kbd?: string
   children: ReactNode
   variant?: 'bottom'
+  hasDot?: boolean
 }) {
   const variantClass = variant === 'bottom' ? ' is-bottom' : ''
   return (
@@ -134,6 +164,7 @@ function NavItem({
     >
       {icon}
       <span>{children}</span>
+      {hasDot && <span className="nav-dot" aria-hidden="true" />}
       {kbd && <span className="nav-kbd">{kbd}</span>}
     </button>
   )

--- a/src/pages/settings/GeneralSettings.tsx
+++ b/src/pages/settings/GeneralSettings.tsx
@@ -71,9 +71,10 @@ export function GeneralSettings({ settings, onChange }: Props) {
 
   const historyTracking = settings.privacy?.historyTracking ?? true
   const targetAppTracking = settings.privacy?.targetAppTracking ?? false
+  const autoCheckUpdates = settings.privacy?.autoCheckUpdates ?? false
 
-  function togglePrivacy(key: 'historyTracking' | 'targetAppTracking') {
-    const current = { historyTracking, targetAppTracking }
+  function togglePrivacy(key: 'historyTracking' | 'targetAppTracking' | 'autoCheckUpdates') {
+    const current = { historyTracking, targetAppTracking, autoCheckUpdates }
     const next = { ...current, [key]: !current[key] }
     // Turning the master off implicitly disables the sub-toggle so we never
     // persist a contradictory "history off, target-app on" state.
@@ -181,6 +182,18 @@ export function GeneralSettings({ settings, onChange }: Props) {
           onClick={() => togglePrivacy('targetAppTracking')}
           className={`v-switch${targetAppTracking && historyTracking ? ' on' : ''}`}
           style={{ opacity: historyTracking ? 1 : 0.4, cursor: historyTracking ? 'pointer' : 'not-allowed' }}
+        />
+      </SettingRow>
+
+      <SettingRow
+        label={t('settings.privacy.autoCheckUpdates')}
+        description={t('settings.privacy.autoCheckUpdatesDesc')}
+      >
+        <button
+          role="switch"
+          aria-checked={autoCheckUpdates}
+          onClick={() => togglePrivacy('autoCheckUpdates')}
+          className={`v-switch${autoCheckUpdates ? ' on' : ''}`}
         />
       </SettingRow>
     </div>

--- a/src/stores/appStore.ts
+++ b/src/stores/appStore.ts
@@ -1,15 +1,17 @@
 import { create } from 'zustand'
-import type { AppState, AppError, Settings } from '../types'
+import type { AppState, AppError, Settings, UpdateInfo } from '../types'
 
 interface AppStore {
   appState: AppState
   error: AppError | null
   settings: Settings | null
   lastTranscription: string | null
+  updateAvailable: UpdateInfo | null
   setAppState: (state: AppState) => void
   setError: (error: AppError | null) => void
   setSettings: (settings: Settings) => void
   setLastTranscription: (text: string) => void
+  setUpdateAvailable: (info: UpdateInfo | null) => void
 }
 
 export const useAppStore = create<AppStore>((set) => ({
@@ -17,8 +19,10 @@ export const useAppStore = create<AppStore>((set) => ({
   error: null,
   settings: null,
   lastTranscription: null,
+  updateAvailable: null,
   setAppState: (appState) => set({ appState }),
   setError: (error) => set({ error }),
   setSettings: (settings) => set({ settings }),
   setLastTranscription: (text) => set({ lastTranscription: text }),
+  setUpdateAvailable: (info) => set({ updateAvailable: info }),
 }))

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -63,7 +63,13 @@ export interface Settings {
   privacy: {
     historyTracking: boolean
     targetAppTracking: boolean
+    autoCheckUpdates: boolean
   }
+}
+
+export interface UpdateInfo {
+  version: string
+  notes: string | null
 }
 
 export type UiLanguage = 'de' | 'en' | 'es' | 'fr' | 'pt' | 'it'


### PR DESCRIPTION
  Closes #10. Adds the Tauri updater + process plugins and wires them into a complete update flow with three discovery surfaces.                                                                                    
                                                                                                                                                                                                                    
  ## What this PR delivers                                                                                                                                                                                          
                                                                                                                                                                                                                    
  **1. Manual check from About page** — explicit "Check for updates" button with full state machine: idle → checking → up-to-date / update-available → downloading (with progress) → ready-to-install → error. Each 
  state has localised copy in all six locales.
                                                                                                                                                                                                                    
  **2. Auto-check on launch (opt-in)** — Settings → Privacy → "Check for updates automatically", default **OFF**. When ON, the app does a single check 5s after launch, only after onboarding is done. No periodic  
  polling, no background timers.
                                                                                                                                                                                                                    
  **3. Pill speech bubble** — when auto-check finds an update and the user is not currently recording, a transparent always-on-top "speech bubble" window appears above the pill with "Hey." + "Update verfügbar:   
  v0.3.4" + Update?/Später buttons. Reuses the pill's monitor-anchor math (`position_status_bar`) and the active-monitor watcher so it follows the cursor across monitors. Auto-dismisses after 10 seconds.
                                                                                                                                                                                                                    
  **4. About-nav-item dot** — a small ember-coloured dot appears on the About nav-item in the sidebar whenever `updateAvailable` is set in the store, regardless of which surface set it. Helps default-OFF users   
  still notice an update they manually checked for.
                                                                                                                                                                                                                    
  ## Backend                                                      

  - `tauri-plugin-updater` (Rust) + `@tauri-apps/plugin-updater` + `tauri-plugin-process` + `@tauri-apps/plugin-process` (npm)                                                                                      
  - New `update-toast` window in `tauri.conf.json` (320×96, transparent, always-on-top, hidden by default)
  - `position_update_toast` helper mirrors the pill's anchor math                                                                                                                                                   
  - `check_for_updates_silently` async task — emits `updater://update-available` event on find and conditionally shows the toast                                                                                    
  - Two new IPC commands: `dismiss_update_toast`, `accept_update_toast` (the latter brings up the main window and emits `updater://navigate-to-about`)                                                              
  - `position_status_bar`'s monitor watcher also repositions the toast when visible                                                                                                                                 
                                                                                                                                                                                                                    
  ## Storage                                                                                                                                                                                                        
                                                                                                                                                                                                                    
  - `privacy.autoCheckUpdates` default `false`                                                                                                                                                                      
  - Merge backfill test for the new key
                                                                                                                                                                                                                    
  ## CI                                                           

  - `release.yml`: `TAURI_SIGNING_PRIVATE_KEY` + `_PASSWORD` env vars wired into the `tauri build` step, NSIS installer is signed with the project's minisign key                                                   
  - After build: `jq` composes `latest.json` from version, signature contents, installer URL — attached to the draft release alongside the NSIS exe and the two SBOMs
  - Updater endpoint: `releases/latest/download/latest.json` (GitHub auto-follows latest non-prerelease tag)                                                                                                        
                                                                                                                                                                                                                    
  ## Capabilities                                                                                                                                                                                                   
                                                                                                                                                                                                                    
  `update-toast` added to the windows list. `updater:default` + `process:default` permissions granted so the JS plugins can run.                                                                                    
  
  ## Step-up release note                                                                                                                                                                                           
                                                                  
  This PR ships in **v0.3.3**. v0.3.4 will be the **first auto-installable** update. Users on v0.3.2 must do one final manual install of v0.3.3 to get the updater code onto their machines.                        
  
  ## Test plan                                                                                                                                                                                                      
                                                                  
  - [ ] Tag-build CI run produces NSIS + 2 SBOMs + latest.json (4 assets, no .sig file leakage as a separate asset)                                                                                                 
  - [ ] Cold install v0.3.3, About page shows "Check for updates" — clicking it returns "You're on the latest version" (assuming v0.3.3 is the most recent tag)
  - [ ] Auto-check toggle in Settings: OFF (default) means no network call on next launch                                                                                                                           
  - [ ] Auto-check ON: relaunch app on v0.3.3 with v0.3.4 available → after 5s, pill speech bubble appears and About-nav-item gains the ember dot                                                                   
  - [ ] During recording: no toast appears, but the dot is still set after the recording ends and user opens About                                                                                                  
  - [ ] Multi-monitor: bubble appears on the same monitor as the pill; moving cursor across monitors during bubble visibility re-pins it                                                                            
  - [ ] Click "Später" on bubble: hides, returns at next launch's auto-check (if ON)                                                                                                                                
  - [ ] Click "Update?" on bubble: bubble hides, main window comes forward, About page is active                                                                                                                    
  - [ ] All six locales render the new strings correctly                                                                                                                                                            
                                                                                                                                                                                                                    
  ## Local compile note                                                                                                                                                                                             
                                                                                                                                                                                                                    
  As with previous Rust-touching PRs, the Pi can't run `cargo check` (rustc 1.85 < required 1.88 for current lockfile deps). Frontend `tsc --noEmit` is clean. CI on `windows-latest` with
  `dtolnay/rust-toolchain@stable` is the authoritative build.                                                                                                                                                       
                                                                  
  closes #10