### PR TITLE
chore: bump version 0.3.2 -> 0.3.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "voca",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "voca",
-      "version": "0.3.2",
+      "version": "0.3.3",
       "dependencies": {
         "@tauri-apps/api": "^2.0.0",
         "@tauri-apps/plugin-process": "^2.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "voca",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -6169,7 +6169,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "voca"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "arboard",
  "base64 0.22.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "voca"
-version = "0.3.2"
+version = "0.3.3"
 description = "VOCA – Speech-to-Text Desktop App"
 authors = []
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "VOCA",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "identifier": "app.voca",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
  ## Changes                                                                                                                                                                                                        
                                                                                                                                                                                                                    
  - `package.json` — top-level `version`                                                                                                                                                                            
  - `package-lock.json` — top-level + `packages.""` self-entry (unrelated `tinyexec@0.3.2` transitive dep left untouched at its own version)                                                                        
  - `src-tauri/tauri.conf.json` — Tauri reads this for the NSIS installer filename                                                          
  - `src-tauri/Cargo.toml` — voca crate version                                                                                                                                                                     
  - `src-tauri/Cargo.lock` — voca crate self-entry only                                                                                                                                                             
                                                                                                                                                                                                                    
  ## After merge                                                                                                                                                                                                    
                                                                                                                                                                                                                    
  1. Merge `develop` → `main` (analog to v0.3.1 / v0.3.2 ship)    
  2. Tag `v0.3.3` on main, push tag                                                                                                                                                                                 
  3. `release.yml` runs the **first signed build** — produces NSIS + 2 SBOMs + new `latest.json` (4 assets total)
  4. Manually publish the draft on GitHub