### PR TITLE
fix(updater): produce signed nsis.zip bundle and use it as updater target

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,6 +59,27 @@ jobs:
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
         run: npm run tauri build -- --bundles nsis
 
+      - name: List bundle directory (diagnostic)
+        if: always()
+        shell: bash
+        run: |
+          echo "=== bundle/nsis contents ==="
+          ls -la src-tauri/target/release/bundle/nsis/ 2>&1 || true
+          echo "=== signing env-var presence (no values printed) ==="
+          if [ -z "${TAURI_SIGNING_PRIVATE_KEY:-}" ]; then
+            echo "TAURI_SIGNING_PRIVATE_KEY: NOT SET"
+          else
+            echo "TAURI_SIGNING_PRIVATE_KEY: SET (length=${#TAURI_SIGNING_PRIVATE_KEY})"
+          fi
+          if [ -z "${TAURI_SIGNING_PRIVATE_KEY_PASSWORD:-}" ]; then
+            echo "TAURI_SIGNING_PRIVATE_KEY_PASSWORD: NOT SET (or empty)"
+          else
+            echo "TAURI_SIGNING_PRIVATE_KEY_PASSWORD: SET (length=${#TAURI_SIGNING_PRIVATE_KEY_PASSWORD})"
+          fi
+        env:
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+
       - name: Upload installer artifact
         uses: actions/upload-artifact@v4
         with:
@@ -91,22 +112,35 @@ jobs:
         run: |
           set -e
           VERSION="${GITHUB_REF#refs/tags/v}"
-          INSTALLER=$(ls src-tauri/target/release/bundle/nsis/*-setup.exe | head -1)
-          SIG_FILE="${INSTALLER}.sig"
-          if [ ! -f "$SIG_FILE" ]; then
-            echo "ERROR: signature file not found at $SIG_FILE"
-            echo "TAURI_SIGNING_PRIVATE_KEY secret may not be set, or the build did not sign."
+          # Tauri 2 produces a .nsis.zip "updater bundle" alongside the .exe
+          # when bundle.createUpdaterArtifacts is true. The .sig pertains to
+          # the .nsis.zip — that's what the updater plugin downloads and
+          # verifies, then it extracts and runs the installer inside.
+          ZIP_FILE=$(ls src-tauri/target/release/bundle/nsis/*-setup.nsis.zip 2>/dev/null | head -1 || true)
+          if [ -z "$ZIP_FILE" ] || [ ! -f "$ZIP_FILE" ]; then
+            echo "ERROR: NSIS updater bundle (.nsis.zip) not produced."
+            echo "Check that bundle.createUpdaterArtifacts is true in tauri.conf.json"
+            echo "and that TAURI_SIGNING_PRIVATE_KEY env var was set during build."
+            echo "See the diagnostic step earlier in this run for bundle directory contents."
             exit 1
           fi
-          INSTALLER_NAME=$(basename "$INSTALLER")
-          INSTALLER_URL="https://github.com/fnnbl/voca-app/releases/download/v${VERSION}/${INSTALLER_NAME}"
+          SIG_FILE="${ZIP_FILE}.sig"
+          if [ ! -f "$SIG_FILE" ]; then
+            echo "ERROR: signature file not found at $SIG_FILE"
+            echo "The .nsis.zip exists but no .sig was produced. Likely cause:"
+            echo "TAURI_SIGNING_PRIVATE_KEY_PASSWORD secret value did not match"
+            echo "the password used when generating the keypair (or empty-vs-set mismatch)."
+            exit 1
+          fi
+          ZIP_NAME=$(basename "$ZIP_FILE")
+          ZIP_URL="https://github.com/fnnbl/voca-app/releases/download/v${VERSION}/${ZIP_NAME}"
           PUB_DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
           jq -n \
             --arg version "$VERSION" \
             --arg notes "See the GitHub release for changes." \
             --arg pub_date "$PUB_DATE" \
             --rawfile signature "$SIG_FILE" \
-            --arg url "$INSTALLER_URL" \
+            --arg url "$ZIP_URL" \
             '{
               version: $version,
               notes: $notes,
@@ -127,6 +161,7 @@ jobs:
         with:
           files: |
             src-tauri/target/release/bundle/nsis/*.exe
+            src-tauri/target/release/bundle/nsis/*.nsis.zip
             sbom.cyclonedx.json
             sbom.spdx.json
             latest.json

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -67,6 +67,7 @@
   },
   "bundle": {
     "active": true,
+    "createUpdaterArtifacts": true,
     "targets": "all",
     "icon": [
       "icons/32x32.png",


### PR DESCRIPTION
  The v0.3.3 tag-build failed because PR #81's workflow looked for `*-setup.exe.sig`, which     
  Tauri 2 doesn't produce for Windows NSIS. The actual updater convention is a separate         
  `.nsis.zip` "updater bundle" alongside the user-facing `.exe`, signed as `.nsis.zip.sig` —    
  that's what the updater plugin downloads, verifies, then extracts and runs.                   
                                                                                              
  ## Changes

  - **tauri.conf.json**: `bundle.createUpdaterArtifacts: true` so the build emits the           
  `.nsis.zip` alongside the `.exe`. Without this flag, Tauri 2.10 doesn't always auto-produce
  the updater bundle even when the updater plugin is configured.                                
  - **release.yml**: look for `*-setup.nsis.zip.sig` instead of `.exe.sig`; latest.json's `url`
  field points at the `.nsis.zip`; the `.nsis.zip` is attached to the release alongside the     
  existing assets so the URL is reachable.
  - **Diagnostic step**: runs `if: always()` after the build, lists `bundle/nsis/` contents,    
  misconfig surfaces in the CI log instead of through retry-and-guess.                          
  - **Refined error messages**: the compose step now distinguishes between (a) `.nsis.zip` 
  missing (config issue: `createUpdaterArtifacts` not set or signing env var missing during     
  build) and (b) `.zip` exists but `.sig` missing (likely password mismatch between secret and  
  keypair).                                                                                    
                                                                                                
  ## Recovery flow after merge                                                                
                              
  1. Merge this PR onto `develop`
  2. Merge `develop` → `main`    
  3. **Delete the failed v0.3.3 tag** (it points to a commit without this fix):                 
     ```bash                                                                   
     git tag -d v0.3.3                                                                          
     git push --delete origin v0.3.3                                                          
  4. Re-tag v0.3.3 on the latest main commit:                                                   
  git checkout main && git pull                                                               
  git tag v0.3.3                                                                                
  git push origin v0.3.3                                                                        
  5. CI runs again, this time with the corrected updater build. Five expected assets in the     
  draft release: .exe, .nsis.zip, .cyclonedx.json, .spdx.json, latest.json.                     
                                                                                                
  If it still fails
                                                                                                
  The diagnostic step's output will pinpoint which problem we have:                             
  - .exe missing → build itself failed (would have errored earlier anyway)
  - .exe exists, .nsis.zip missing → createUpdaterArtifacts not picked up (Tauri config issue)  
  - .zip exists, .sig missing → password mismatch in the GitHub Secret                        
  - All three exist → workflow's path computation is wrong, look at filename pattern