### PR TITLE
Release v0.3.3 (fix-forward for updater build signing)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,6 +59,27 @@ jobs:
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
         run: npm run tauri build -- --bundles nsis
 
+      - name: List bundle directory (diagnostic)
+        if: always()
+        shell: bash
+        run: |
+          echo "=== bundle/nsis contents ==="
+          ls -la src-tauri/target/release/bundle/nsis/ 2>&1 || true
+          echo "=== signing env-var presence (no values printed) ==="
+          if [ -z "${TAURI_SIGNING_PRIVATE_KEY:-}" ]; then
+            echo "TAURI_SIGNING_PRIVATE_KEY: NOT SET"
+          else
+            echo "TAURI_SIGNING_PRIVATE_KEY: SET (length=${#TAURI_SIGNING_PRIVATE_KEY})"
+          fi
+          if [ -z "${TAURI_SIGNING_PRIVATE_KEY_PASSWORD:-}" ]; then
+            echo "TAURI_SIGNING_PRIVATE_KEY_PASSWORD: NOT SET (or empty)"
+          else
+            echo "TAURI_SIGNING_PRIVATE_KEY_PASSWORD: SET (length=${#TAURI_SIGNING_PRIVATE_KEY_PASSWORD})"
+          fi
+        env:
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+
       - name: Upload installer artifact
         uses: actions/upload-artifact@v4
         with:
@@ -91,22 +112,35 @@ jobs:
         run: |
           set -e
           VERSION="${GITHUB_REF#refs/tags/v}"
-          INSTALLER=$(ls src-tauri/target/release/bundle/nsis/*-setup.exe | head -1)
-          SIG_FILE="${INSTALLER}.sig"
-          if [ ! -f "$SIG_FILE" ]; then
-            echo "ERROR: signature file not found at $SIG_FILE"
-            echo "TAURI_SIGNING_PRIVATE_KEY secret may not be set, or the build did not sign."
+          # Tauri 2 produces a .nsis.zip "updater bundle" alongside the .exe
+          # when bundle.createUpdaterArtifacts is true. The .sig pertains to
+          # the .nsis.zip — that's what the updater plugin downloads and
+          # verifies, then it extracts and runs the installer inside.
+          ZIP_FILE=$(ls src-tauri/target/release/bundle/nsis/*-setup.nsis.zip 2>/dev/null | head -1 || true)
+          if [ -z "$ZIP_FILE" ] || [ ! -f "$ZIP_FILE" ]; then
+            echo "ERROR: NSIS updater bundle (.nsis.zip) not produced."
+            echo "Check that bundle.createUpdaterArtifacts is true in tauri.conf.json"
+            echo "and that TAURI_SIGNING_PRIVATE_KEY env var was set during build."
+            echo "See the diagnostic step earlier in this run for bundle directory contents."
             exit 1
           fi
-          INSTALLER_NAME=$(basename "$INSTALLER")
-          INSTALLER_URL="https://github.com/fnnbl/voca-app/releases/download/v${VERSION}/${INSTALLER_NAME}"
+          SIG_FILE="${ZIP_FILE}.sig"
+          if [ ! -f "$SIG_FILE" ]; then
+            echo "ERROR: signature file not found at $SIG_FILE"
+            echo "The .nsis.zip exists but no .sig was produced. Likely cause:"
+            echo "TAURI_SIGNING_PRIVATE_KEY_PASSWORD secret value did not match"
+            echo "the password used when generating the keypair (or empty-vs-set mismatch)."
+            exit 1
+          fi
+          ZIP_NAME=$(basename "$ZIP_FILE")
+          ZIP_URL="https://github.com/fnnbl/voca-app/releases/download/v${VERSION}/${ZIP_NAME}"
           PUB_DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
           jq -n \
             --arg version "$VERSION" \
             --arg notes "See the GitHub release for changes." \
             --arg pub_date "$PUB_DATE" \
             --rawfile signature "$SIG_FILE" \
-            --arg url "$INSTALLER_URL" \
+            --arg url "$ZIP_URL" \
             '{
               version: $version,
               notes: $notes,
@@ -127,6 +161,7 @@ jobs:
         with:
           files: |
             src-tauri/target/release/bundle/nsis/*.exe
+            src-tauri/target/release/bundle/nsis/*.nsis.zip
             sbom.cyclonedx.json
             sbom.spdx.json
             latest.json

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -67,6 +67,7 @@
   },
   "bundle": {
     "active": true,
+    "createUpdaterArtifacts": true,
     "targets": "all",
     "icon": [
       "icons/32x32.png",


### PR DESCRIPTION
  Brings the `fix/updater-build-signing` branch (PR-merged on develop) onto main so v0.3.3 can  
  be re-tagged with a working signed-build pipeline.                                            
   
  ## What's in this release                                                                     
                                                            
  - Auto-updater feature (PR #81, closes #10) — already on main from the first v0.3.3 attempt   
  - Build pipeline fix for the auto-updater (PR-merged via the fix-forward branch on develop) —
  the actual delta this PR carries to main: `bundle.createUpdaterArtifacts: true` in            
  tauri.conf.json + release.yml looks for `.nsis.zip.sig` instead of `.exe.sig` + diagnostic
  step + `.nsis.zip` attached to the release                                                    
                                                            
  ## Why a fix-forward instead of a v0.3.4 release                                              
   
  The original v0.3.3 tag-build failed at the "Compose latest.json" step — no GitHub release was
  have anything to roll back from. Cleanest path: delete the failed tag, re-tag v0.3.3 on the 
  new merged commit. Saves a version number and keeps the auto-updater story coherent ("v0.3.3 =
   updater introduced" stays true).                                                             
                                   
  ## After merge — re-tag flow
                              
  ```bash
  # Delete the failed v0.3.3 tag
  git tag -d v0.3.3             
  git push --delete origin v0.3.3                                                               
                                 
  # Re-tag on the new main HEAD (this PR's merge commit)                                        
  git checkout main && git pull                             
  git tag v0.3.3                                                                                
  git push origin v0.3.3
                                                                                                
  CI then runs the corrected pipeline. Five expected assets in the draft release:               
  - VOCA_0.3.3_x64-setup.exe (manual install)
  - VOCA_0.3.3_x64-setup.nsis.zip (updater download target)                                     
  - sbom.cyclonedx.json                                     
  - sbom.spdx.json                                                                              
  - latest.json (updater manifest, points at the .nsis.zip) 
                                                                                                
  Diagnostic safety net                                                                         
                                                                                                
  The release.yml now has an if: always() diagnostic step that prints the bundle/nsis/ directory
   contents and reports the presence (length only, never values) of both signing env vars. If
  anything is still off, the next CI run will say so explicitly instead of "signature file not  
  found".