### PR TITLE
fix(updater): use .exe.sig directly, drop wrong .nsis.zip assumption

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -112,35 +112,32 @@ jobs:
         run: |
           set -e
           VERSION="${GITHUB_REF#refs/tags/v}"
-          # Tauri 2 produces a .nsis.zip "updater bundle" alongside the .exe
-          # when bundle.createUpdaterArtifacts is true. The .sig pertains to
-          # the .nsis.zip — that's what the updater plugin downloads and
-          # verifies, then it extracts and runs the installer inside.
-          ZIP_FILE=$(ls src-tauri/target/release/bundle/nsis/*-setup.nsis.zip 2>/dev/null | head -1 || true)
-          if [ -z "$ZIP_FILE" ] || [ ! -f "$ZIP_FILE" ]; then
-            echo "ERROR: NSIS updater bundle (.nsis.zip) not produced."
-            echo "Check that bundle.createUpdaterArtifacts is true in tauri.conf.json"
-            echo "and that TAURI_SIGNING_PRIVATE_KEY env var was set during build."
-            echo "See the diagnostic step earlier in this run for bundle directory contents."
-            exit 1
-          fi
-          SIG_FILE="${ZIP_FILE}.sig"
+          # Tauri 2 with NSIS + bundle.createUpdaterArtifacts=true produces
+          # the .exe.sig directly next to the .exe. There is no .nsis.zip
+          # wrapper in this configuration — the updater plugin downloads
+          # the .exe, verifies the signature, and runs it as a passive
+          # installer.
+          INSTALLER=$(ls src-tauri/target/release/bundle/nsis/*-setup.exe | head -1)
+          SIG_FILE="${INSTALLER}.sig"
           if [ ! -f "$SIG_FILE" ]; then
             echo "ERROR: signature file not found at $SIG_FILE"
-            echo "The .nsis.zip exists but no .sig was produced. Likely cause:"
-            echo "TAURI_SIGNING_PRIVATE_KEY_PASSWORD secret value did not match"
-            echo "the password used when generating the keypair (or empty-vs-set mismatch)."
+            echo "The .exe exists but no .sig was produced. Likely causes:"
+            echo "  - bundle.createUpdaterArtifacts not true in tauri.conf.json"
+            echo "  - TAURI_SIGNING_PRIVATE_KEY env var empty during build"
+            echo "  - TAURI_SIGNING_PRIVATE_KEY_PASSWORD value mismatches the"
+            echo "    password used when the keypair was generated"
+            echo "See the diagnostic step earlier in this run for evidence."
             exit 1
           fi
-          ZIP_NAME=$(basename "$ZIP_FILE")
-          ZIP_URL="https://github.com/fnnbl/voca-app/releases/download/v${VERSION}/${ZIP_NAME}"
+          INSTALLER_NAME=$(basename "$INSTALLER")
+          INSTALLER_URL="https://github.com/fnnbl/voca-app/releases/download/v${VERSION}/${INSTALLER_NAME}"
           PUB_DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
           jq -n \
             --arg version "$VERSION" \
             --arg notes "See the GitHub release for changes." \
             --arg pub_date "$PUB_DATE" \
             --rawfile signature "$SIG_FILE" \
-            --arg url "$ZIP_URL" \
+            --arg url "$INSTALLER_URL" \
             '{
               version: $version,
               notes: $notes,
@@ -161,7 +158,6 @@ jobs:
         with:
           files: |
             src-tauri/target/release/bundle/nsis/*.exe
-            src-tauri/target/release/bundle/nsis/*.nsis.zip
             sbom.cyclonedx.json
             sbom.spdx.json
             latest.json


### PR DESCRIPTION
  The previous fix-forward (PR #84) was based on a wrong assumption about Tauri 2's NSIS build
  behaviour. **The diagnostic step from the second tag-build attempt proved it** — bundle/nsis/ 
  contained:                                                                                    
            
  VOCA_0.3.3_x64-setup.exe       (4.6 MB, the installer)                                        
  VOCA_0.3.3_x64-setup.exe.sig   (412 bytes, the signature) ✓                                   
                                                                                                
  No `.nsis.zip`, no `.nsis.zip.sig`. Tauri 2.10 with `bundle.createUpdaterArtifacts: true`     
  produces `.exe.sig` directly. That code path is what the updater plugin already supports for  
  Windows NSIS.                                             
                                                                                                
  Signing was actually working in the second attempt — my workflow was just looking for the     
  wrong file. Five fixes nested:
                                                                                                
  - Look for `*-setup.exe.sig` (not `*-setup.nsis.zip.sig`)                                     
  - `latest.json` `url` field points at the `.exe` (not `.nsis.zip`)
  - Drop `*.nsis.zip` from the Publish files glob (it was never produced)                       
  - Keep `bundle.createUpdaterArtifacts: true` in tauri.conf.json — it's still what triggers    
  signing; without it the env var alone doesn't produce a `.sig` in Tauri 2.10 (we've now seen  
  this in two prior runs)                                                                       
  - Refine the `.sig-missing` error message with the three realistic root causes for future     
  maintainers                                               

  ## Recovery flow after merge                                                                  
  
  1. Merge this PR onto `develop`                                                               
  2. Merge `develop` → `main`                               
  3. Delete the failed v0.3.3 tag, re-tag on the new main HEAD:                                 
     ```bash                                                                                    
     git tag -d v0.3.3
     git push --delete origin v0.3.3                                                            
     git checkout main && git pull                          
     git tag v0.3.3                                                                             
     git push origin v0.3.3
                                                                                                
  Expected output after re-tag                                                                  
  
  - Diagnostic step: same as before (.exe + .exe.sig in bundle dir, env vars set/empty          
  correctly)                                                
  - Compose step: succeeds, prints the latest.json content                                      
  - Draft release: four assets — .exe, .cyclonedx.json, .spdx.json, latest.json (no .nsis.zip   
  since it doesn't exist)                                                                       
                                                                                                
  Why two fix-forwards                                                                          
                                                            
  The first fix forward changed too many things at once based on a hypothesis I hadn't verified.
   The diagnostic step that the same fix added saved us this round — without it, this would have
   been retry-and-guess again. Lesson recorded for future signing-pipeline-style work.