### PR TITLE
chore(ci): deduplicate workflow triggers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,9 @@ name: CI
 
 on:
   push:
-    branches: ['**']
+    branches:
+      - develop
+      - main
   pull_request:
     branches: ['**']
 


### PR DESCRIPTION
Narrows the `push` trigger in `ci.yml` from `['**']` to `[develop, main]` so a PR commit no longer triggers the same jobs twice (once from `push` on the source branch, once from `pull_request`). `sbom.yml` and
  `release.yml` already restrict their push triggers to the protected branches, so no change is needed there.
  
  ## Changes
  
  - `ci.yml`: `push: branches: ['**']` → `push: branches: [develop, main]`
  - `pull_request` scope unchanged — still validates every PR

  ## Trade-off
  
  Feature branches with no open PR no longer get CI on push. In this repo every feature branch gets a PR immediately, so PR-trigger coverage is equivalent.
  
  ## Verification
  
  - This PR itself should show roughly half as many check entries as previous PRs
  - Post-merge push to `develop` still triggers the full CI job set

  Closes #64