### PR TITLE
feat: custom local Whisper model import

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.3.3",
       "dependencies": {
         "@tauri-apps/api": "^2.0.0",
+        "@tauri-apps/plugin-dialog": "^2.0.0",
         "@tauri-apps/plugin-process": "^2.3.1",
         "@tauri-apps/plugin-shell": "^2.0.0",
         "@tauri-apps/plugin-updater": "^2.10.1",
@@ -1668,9 +1669,9 @@
       ]
     },
     "node_modules/@tauri-apps/api": {
-      "version": "2.10.1",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/api/-/api-2.10.1.tgz",
-      "integrity": "sha512-hKL/jWf293UDSUN09rR69hrToyIXBb8CjGaWC7gfinvnQrBVvnLr08FeFi38gxtugAVyVcTa5/FD/Xnkb1siBw==",
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/api/-/api-2.11.0.tgz",
+      "integrity": "sha512-7CinYODhky9lmO23xHnUFv0Xt43fbtWMyxZcLcRBlFkcgXKuEirBvHpmtJ89YMhyeGcq20Wuc47Fa4XjyniywA==",
       "license": "Apache-2.0 OR MIT",
       "funding": {
         "type": "opencollective",
@@ -1892,6 +1893,15 @@
       ],
       "engines": {
         "node": ">= 10"
+      }
+    },
+    "node_modules/@tauri-apps/plugin-dialog": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/plugin-dialog/-/plugin-dialog-2.7.1.tgz",
+      "integrity": "sha512-OK1UBXYt+ojcmxMktzzuyonYIFta8CmAASpX+CA+DTGK24KlHjhYI6x2iOJ/TjZF4N7/ACK1oFmEOjIY9IhzOQ==",
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "@tauri-apps/api": "^2.11.0"
       }
     },
     "node_modules/@tauri-apps/plugin-process": {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   },
   "dependencies": {
     "@tauri-apps/api": "^2.0.0",
+    "@tauri-apps/plugin-dialog": "^2.0.0",
     "@tauri-apps/plugin-process": "^2.3.1",
     "@tauri-apps/plugin-shell": "^2.0.0",
     "@tauri-apps/plugin-updater": "^2.10.1",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1029,13 +1029,19 @@ dependencies = [
 
 [[package]]
 name = "ctor"
-version = "0.2.9"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a2785755761f3ddc1492979ce1e48d2c00d09311c39e4466429188f3dd6501"
+checksum = "352d39c2f7bef1d6ad73db6f5160efcaed66d94ef8c6c573a8410c00bf909a98"
 dependencies = [
- "quote",
- "syn 2.0.117",
+ "ctor-proc-macro",
+ "dtor",
 ]
+
+[[package]]
+name = "ctor-proc-macro"
+version = "0.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52560adf09603e58c9a7ee1fe1dcb95a16927b17c127f0ac02d6e768a0e25bc1"
 
 [[package]]
 name = "darling"
@@ -1076,6 +1082,17 @@ name = "dasp_sample"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c87e182de0887fd5361989c677c4e8f5000cd9491d6d563161a8f3a5519fc7f"
+
+[[package]]
+name = "dbus"
+version = "0.9.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b942602992bb7acfd1f51c49811c58a610ef9181b6e66f3e519d79b540a3bf73"
+dependencies = [
+ "libc",
+ "libdbus-sys",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "deranged"
@@ -1192,7 +1209,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1279,6 +1296,21 @@ checksum = "cd1511a7b6a56299bd043a9c167a6d2bfb37bf84a6dfceaba651168adfb43c87"
 dependencies = [
  "dtoa",
 ]
+
+[[package]]
+name = "dtor"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1057d6c64987086ff8ed0fd3fbf377a6b7d205cc7715868cd401705f715cbe4"
+dependencies = [
+ "dtor-proc-macro",
+]
+
+[[package]]
+name = "dtor-proc-macro"
+version = "0.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f678cf4a922c215c63e0de95eb1ff08a958a81d47e485cf9da1e27bf6305cfa5"
 
 [[package]]
 name = "dunce"
@@ -1395,7 +1427,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2252,7 +2284,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.2",
+ "windows-core 0.56.0",
 ]
 
 [[package]]
@@ -2716,6 +2748,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
 
 [[package]]
+name = "libdbus-sys"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "328c4789d42200f1eeec05bd86c9c13c7f091d2ba9a6ea35acdf51f31bc0f043"
+dependencies = [
+ "pkg-config",
+]
+
+[[package]]
 name = "libloading"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2974,9 +3015,9 @@ dependencies = [
 
 [[package]]
 name = "muda"
-version = "0.17.2"
+version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c9fec5a4e89860383d778d10563a605838f8f0b2f9303868937e5ff32e86177"
+checksum = "0ae8844f63b5b118e334e205585b8c5c17b984121dbdb179d44aeb087ffad3cb"
 dependencies = [
  "crossbeam-channel",
  "dpi",
@@ -2987,7 +3028,7 @@ dependencies = [
  "objc2-core-foundation",
  "objc2-foundation 0.3.2",
  "once_cell",
- "png 0.17.16",
+ "png 0.18.1",
  "serde",
  "thiserror 2.0.18",
  "windows-sys 0.60.2",
@@ -3251,8 +3292,8 @@ dependencies = [
  "block2 0.5.1",
  "libc",
  "objc2 0.5.2",
- "objc2-core-data",
- "objc2-core-image",
+ "objc2-core-data 0.2.2",
+ "objc2-core-image 0.2.2",
  "objc2-foundation 0.2.2",
  "objc2-quartz-core 0.2.2",
 ]
@@ -3272,6 +3313,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-cloud-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73ad74d880bb43877038da939b7427bba67e9dd42004a18b809ba7d87cee241c"
+dependencies = [
+ "bitflags 2.11.1",
+ "objc2 0.6.4",
+ "objc2-foundation 0.3.2",
+]
+
+[[package]]
 name = "objc2-core-data"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3281,6 +3333,16 @@ dependencies = [
  "block2 0.5.1",
  "objc2 0.5.2",
  "objc2-foundation 0.2.2",
+]
+
+[[package]]
+name = "objc2-core-data"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b402a653efbb5e82ce4df10683b6b28027616a2715e90009947d50b8dd298fa"
+dependencies = [
+ "objc2 0.6.4",
+ "objc2-foundation 0.3.2",
 ]
 
 [[package]]
@@ -3317,6 +3379,38 @@ dependencies = [
  "objc2 0.5.2",
  "objc2-foundation 0.2.2",
  "objc2-metal",
+]
+
+[[package]]
+name = "objc2-core-image"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5d563b38d2b97209f8e861173de434bd0214cf020e3423a52624cd1d989f006"
+dependencies = [
+ "objc2 0.6.4",
+ "objc2-foundation 0.3.2",
+]
+
+[[package]]
+name = "objc2-core-location"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca347214e24bc973fc025fd0d36ebb179ff30536ed1f80252706db19ee452009"
+dependencies = [
+ "objc2 0.6.4",
+ "objc2-foundation 0.3.2",
+]
+
+[[package]]
+name = "objc2-core-text"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cde0dfb48d25d2b4862161a4d5fcc0e3c24367869ad306b0c9ec0073bfed92d"
+dependencies = [
+ "bitflags 2.11.1",
+ "objc2 0.6.4",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
 ]
 
 [[package]]
@@ -3426,8 +3520,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d87d638e33c06f577498cbcc50491496a3ed4246998a7fbba7ccb98b1e7eab22"
 dependencies = [
  "bitflags 2.11.1",
+ "block2 0.6.2",
  "objc2 0.6.4",
+ "objc2-cloud-kit",
+ "objc2-core-data 0.3.2",
  "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-core-image 0.3.2",
+ "objc2-core-location",
+ "objc2-core-text",
+ "objc2-foundation 0.3.2",
+ "objc2-quartz-core 0.3.2",
+ "objc2-user-notifications",
+]
+
+[[package]]
+name = "objc2-user-notifications"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9df9128cbbfef73cda168416ccf7f837b62737d748333bfe9ab71c245d76613e"
+dependencies = [
+ "objc2 0.6.4",
  "objc2-foundation 0.3.2",
 ]
 
@@ -3515,7 +3628,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -3624,7 +3737,6 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
 dependencies = [
- "phf_macros 0.11.3",
  "phf_shared 0.11.3",
 ]
 
@@ -3721,19 +3833,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
-]
-
-[[package]]
-name = "phf_macros"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f84ac04429c13a7ff43785d75ad27569f2951ce0ffd30a3321230db2fc727216"
-dependencies = [
- "phf_generator 0.11.3",
- "phf_shared 0.11.3",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
 ]
 
 [[package]]
@@ -4487,7 +4586,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4544,7 +4643,7 @@ dependencies = [
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5049,7 +5148,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5241,15 +5340,16 @@ dependencies = [
 
 [[package]]
 name = "tao"
-version = "0.34.8"
+version = "0.35.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9103edf55f2da3c82aea4c7fab7c4241032bfeea0e71fa557d98e00e7ce7cc20"
+checksum = "a33f7f9e486ade65fcf1e45c440f9236c904f5c1002cdc7fc6ae582777345ce4"
 dependencies = [
  "bitflags 2.11.1",
  "block2 0.6.2",
  "core-foundation 0.10.1",
  "core-graphics 0.25.0",
  "crossbeam-channel",
+ "dbus",
  "dispatch2",
  "dlopen2",
  "dpi",
@@ -5260,13 +5360,14 @@ dependencies = [
  "libc",
  "log",
  "ndk 0.9.0",
- "ndk-context",
  "ndk-sys 0.6.0+11769913",
  "objc2 0.6.4",
  "objc2-app-kit 0.3.2",
  "objc2-foundation 0.3.2",
+ "objc2-ui-kit",
  "once_cell",
  "parking_lot",
+ "percent-encoding",
  "raw-window-handle",
  "tao-macros",
  "unicode-segmentation",
@@ -5307,9 +5408,9 @@ checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
 
 [[package]]
 name = "tauri"
-version = "2.10.3"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da77cc00fb9028caf5b5d4650f75e31f1ef3693459dfca7f7e506d1ecef0ba2d"
+checksum = "b93bd86d231f0a8138f11a02a584769fe4b703dc36ae133d783228dbc4801405"
 dependencies = [
  "anyhow",
  "bytes",
@@ -5359,9 +5460,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-build"
-version = "2.5.6"
+version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bbc990d1dbf57a8e1c7fa2327f2a614d8b757805603c1b9ba5c81bade09fd4d"
+checksum = "3a318b234cc2dea65f575467bafcfb76286bce228ebc3778e337d61d03213007"
 dependencies = [
  "anyhow",
  "cargo_toml",
@@ -5375,15 +5476,14 @@ dependencies = [
  "serde_json",
  "tauri-utils",
  "tauri-winres",
- "toml 0.9.12+spec-1.1.0",
  "walkdir",
 ]
 
 [[package]]
 name = "tauri-codegen"
-version = "2.5.5"
+version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4a24476afd977c5d5d169f72425868613d82747916dd29e0a357c84c4bd6d29"
+checksum = "6bd11644962add2549a60b7e7c6800f17d7020156e02f516021d8103e80cc528"
 dependencies = [
  "base64 0.22.1",
  "brotli",
@@ -5408,9 +5508,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-macros"
-version = "2.5.5"
+version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d39b349a98dadaffebb73f0a40dcd1f23c999211e5a2e744403db384d0c33de7"
+checksum = "fed9d3742a37a355d2e47c9af924e9fbc112abb76f9835d35d4780e318419502"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
@@ -5578,9 +5678,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-runtime"
-version = "2.10.1"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2826d79a3297ed08cd6ea7f412644ef58e32969504bc4fbd8d7dbeabc4445ea2"
+checksum = "8fef478ba1d2ac21c2d528740b24d0cb315e1e8b1111aae53fafac34804371fc"
 dependencies = [
  "cookie",
  "dpi",
@@ -5603,9 +5703,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-runtime-wry"
-version = "2.10.1"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e11ea2e6f801d275fdd890d6c9603736012742a1c33b96d0db788c9cdebf7f9e"
+checksum = "a3989df2ae1c476404fe0a2e8ffc4cfbde97e51efd613c2bb5355fbc9ab52cf0"
 dependencies = [
  "gtk",
  "http",
@@ -5629,14 +5729,15 @@ dependencies = [
 
 [[package]]
 name = "tauri-utils"
-version = "2.8.3"
+version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "219a1f983a2af3653f75b5747f76733b0da7ff03069c7a41901a5eb3ace4557d"
+checksum = "d57200389a2f82b4b0a40ae29ca19b6978116e8f4d4e974c3234ce40c0ffbdec"
 dependencies = [
  "anyhow",
  "brotli",
  "cargo_metadata",
  "ctor",
+ "dom_query",
  "dunce",
  "glob",
  "html5ever 0.29.1",
@@ -5646,7 +5747,8 @@ dependencies = [
  "kuchikiki",
  "log",
  "memchr",
- "phf 0.11.3",
+ "phf 0.13.1",
+ "plist",
  "proc-macro2",
  "quote",
  "regex",
@@ -5658,7 +5760,7 @@ dependencies = [
  "serde_with",
  "swift-rs",
  "thiserror 2.0.18",
- "toml 0.9.12+spec-1.1.0",
+ "toml 1.1.2+spec-1.1.0",
  "url",
  "urlpattern",
  "uuid",
@@ -5698,7 +5800,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6067,9 +6169,9 @@ dependencies = [
 
 [[package]]
 name = "tray-icon"
-version = "0.21.3"
+version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5e85aa143ceb072062fc4d6356c1b520a51d636e7bc8e77ec94be3608e5e80c"
+checksum = "15edbb0d80583e85ee8df283410038e17314df5cba30da2087a54a85216c0773"
 dependencies = [
  "crossbeam-channel",
  "dirs 6.0.0",
@@ -6081,7 +6183,7 @@ dependencies = [
  "objc2-core-graphics",
  "objc2-foundation 0.3.2",
  "once_cell",
- "png 0.17.16",
+ "png 0.18.1",
  "serde",
  "thiserror 2.0.18",
  "windows-sys 0.60.2",
@@ -6113,7 +6215,7 @@ checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset 0.9.1",
  "tempfile",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6639,7 +6741,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -6761,19 +6863,6 @@ dependencies = [
  "windows-link 0.1.3",
  "windows-result 0.3.4",
  "windows-strings 0.4.2",
-]
-
-[[package]]
-name = "windows-core"
-version = "0.62.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
-dependencies = [
- "windows-implement 0.60.2",
- "windows-interface 0.59.3",
- "windows-link 0.2.1",
- "windows-result 0.4.1",
- "windows-strings 0.5.1",
 ]
 
 [[package]]
@@ -6903,15 +6992,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "windows-result"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
-dependencies = [
- "windows-link 0.2.1",
-]
-
-[[package]]
 name = "windows-strings"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6928,15 +7008,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
 dependencies = [
  "windows-link 0.1.3",
-]
-
-[[package]]
-name = "windows-strings"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
-dependencies = [
- "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -7402,9 +7473,9 @@ checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "wry"
-version = "0.54.4"
+version = "0.55.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5a8135d8676225e5744de000d4dff5a082501bf7db6a1c1495034f8c314edbc"
+checksum = "186f9871daa55fd9c016578b810d149de58367113db7fb72b462d2323ce19514"
 dependencies = [
  "base64 0.22.1",
  "block2 0.6.2",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4398,6 +4398,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "rfd"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a15ad77d9e70a92437d8f74c35d99b4e4691128df018833e99f90bcd36152672"
+dependencies = [
+ "block2 0.6.2",
+ "dispatch2",
+ "glib-sys",
+ "gobject-sys",
+ "gtk-sys",
+ "js-sys",
+ "log",
+ "objc2 0.6.4",
+ "objc2-app-kit 0.3.2",
+ "objc2-core-foundation",
+ "objc2-foundation 0.3.2",
+ "raw-window-handle",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5428,6 +5452,48 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-dialog"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65981abb771e74e571a38196c3baa11c459379164791eba0e67abc1a5fac9884"
+dependencies = [
+ "log",
+ "raw-window-handle",
+ "rfd",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "tauri-plugin-fs",
+ "thiserror 2.0.18",
+ "url",
+]
+
+[[package]]
+name = "tauri-plugin-fs"
+version = "2.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7ecc274121aca0c036a2b42d1cbe83d368d348f54e0bb8a735c2b1548e8f371"
+dependencies = [
+ "anyhow",
+ "dunce",
+ "glob",
+ "log",
+ "objc2-foundation 0.3.2",
+ "percent-encoding",
+ "schemars 0.8.22",
+ "serde",
+ "serde_json",
+ "serde_repr",
+ "tauri",
+ "tauri-plugin",
+ "tauri-utils",
+ "thiserror 2.0.18",
+ "toml 1.1.2+spec-1.1.0",
+ "url",
+]
+
+[[package]]
 name = "tauri-plugin-notification"
 version = "2.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5831,6 +5897,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
+dependencies = [
+ "indexmap 2.14.0",
+ "serde_core",
+ "serde_spanned 1.1.1",
+ "toml_datetime 1.1.1+spec-1.1.0",
+ "toml_parser",
+ "toml_writer",
+ "winnow 1.0.1",
+]
+
+[[package]]
 name = "toml_datetime"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6190,6 +6271,7 @@ dependencies = [
  "tauri",
  "tauri-build",
  "tauri-plugin-autostart",
+ "tauri-plugin-dialog",
  "tauri-plugin-notification",
  "tauri-plugin-process",
  "tauri-plugin-shell",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -20,6 +20,7 @@ tauri-build = { version = "2", features = [] }
 [dependencies]
 tauri = { version = "2", features = ["tray-icon", "image-png"] }
 tauri-plugin-autostart = "2"
+tauri-plugin-dialog = "2"
 tauri-plugin-notification = "2"
 tauri-plugin-process = "2"
 tauri-plugin-shell = "2"

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -7,6 +7,7 @@
     "core:default",
     "shell:allow-open",
     "notification:default",
+    "dialog:default",
     "updater:default",
     "process:default"
   ]

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -266,6 +266,142 @@ pub fn cancel_model_download(app: tauri::AppHandle) -> Result<(), String> {
     Ok(())
 }
 
+#[derive(Clone, serde::Serialize)]
+pub struct CustomModelInfo {
+    pub filename: String,
+    pub size_bytes: u64,
+}
+
+#[derive(Clone, serde::Serialize)]
+pub struct ImportModelResult {
+    pub filename: String,
+    pub size_bytes: u64,
+}
+
+/// Whisper.cpp model files start with magic bytes. The legacy GGML
+/// format uses ASCII `ggml`; the newer GGUF format uses ASCII `GGUF`.
+/// Anything else is rejected before we let `whisper-rs` try to load it
+/// (which would otherwise abort the whole process on malformed input).
+fn validate_whisper_model_magic(path: &std::path::Path) -> Result<(), String> {
+    use std::io::Read;
+    let mut file = std::fs::File::open(path).map_err(|e| format!("STORAGE_ERROR: {e}"))?;
+    let mut header = [0u8; 4];
+    file.read_exact(&mut header)
+        .map_err(|_| "INVALID_MODEL: file too short to be a Whisper model".to_string())?;
+    if &header == b"ggml" || &header == b"GGUF" {
+        Ok(())
+    } else {
+        Err("INVALID_MODEL: not a whisper.cpp compatible model (expected ggml or GGUF header)".to_string())
+    }
+}
+
+/// Accepts only safe basenames with a `.bin` extension (case-insensitive
+/// on the extension, original case preserved on the stem). Anything that
+/// looks like a path component, hidden file, or contains characters that
+/// are invalid on Windows is rejected.
+fn sanitise_model_filename(raw: &str) -> Result<String, String> {
+    if !raw.to_ascii_lowercase().ends_with(".bin") {
+        return Err("INVALID_MODEL: file must have a .bin extension".to_string());
+    }
+    let stem = &raw[..raw.len() - 4];
+    if stem.is_empty()
+        || stem.starts_with('.')
+        || stem.contains('/')
+        || stem.contains('\\')
+        || stem.contains("..")
+        || stem
+            .chars()
+            .any(|c| matches!(c, '<' | '>' | ':' | '"' | '|' | '?' | '*' | '\0'))
+    {
+        return Err("INVALID_MODEL: filename contains invalid characters".to_string());
+    }
+    Ok(format!("{stem}.bin"))
+}
+
+pub fn custom_models_dir(app: &tauri::AppHandle) -> Result<PathBuf, String> {
+    app.path()
+        .app_data_dir()
+        .map(|p| p.join("models").join("custom"))
+        .map_err(|e| format!("STORAGE_ERROR: {e}"))
+}
+
+pub fn custom_model_path(app: &tauri::AppHandle, filename: &str) -> Result<PathBuf, String> {
+    let safe = sanitise_model_filename(filename)?;
+    Ok(custom_models_dir(app)?.join(safe))
+}
+
+#[tauri::command]
+pub fn list_custom_models(app: tauri::AppHandle) -> Result<Vec<CustomModelInfo>, String> {
+    let dir = custom_models_dir(&app)?;
+    if !dir.exists() {
+        return Ok(Vec::new());
+    }
+    let mut out = Vec::new();
+    for entry in std::fs::read_dir(&dir).map_err(|e| format!("STORAGE_ERROR: {e}"))? {
+        let entry = entry.map_err(|e| format!("STORAGE_ERROR: {e}"))?;
+        let path = entry.path();
+        if !path.is_file() {
+            continue;
+        }
+        let filename = match path.file_name().and_then(|n| n.to_str()) {
+            Some(n) if n.to_ascii_lowercase().ends_with(".bin") => n.to_owned(),
+            _ => continue,
+        };
+        let size_bytes = path.metadata().map(|m| m.len()).unwrap_or(0);
+        out.push(CustomModelInfo { filename, size_bytes });
+    }
+    out.sort_by(|a, b| a.filename.to_ascii_lowercase().cmp(&b.filename.to_ascii_lowercase()));
+    Ok(out)
+}
+
+#[tauri::command]
+pub async fn import_custom_model(
+    app: tauri::AppHandle,
+    source_path: String,
+    overwrite: bool,
+) -> Result<ImportModelResult, String> {
+    let source = std::path::PathBuf::from(&source_path);
+    let raw_name = source
+        .file_name()
+        .and_then(|n| n.to_str())
+        .ok_or_else(|| "INVALID_MODEL: source path has no filename".to_string())?
+        .to_owned();
+    let filename = sanitise_model_filename(&raw_name)?;
+
+    validate_whisper_model_magic(&source)?;
+
+    let dest = custom_model_path(&app, &filename)?;
+    if let Some(parent) = dest.parent() {
+        std::fs::create_dir_all(parent).map_err(|e| format!("STORAGE_ERROR: {e}"))?;
+    }
+
+    if dest.exists() && !overwrite {
+        return Err("MODEL_ALREADY_EXISTS".to_string());
+    }
+
+    // Stage via a sibling .tmp then atomic-rename so a partial copy
+    // (interrupted multi-GB transfer) never appears in the model list.
+    let tmp = dest.with_extension("bin.tmp");
+    tokio::fs::copy(&source, &tmp)
+        .await
+        .map_err(|e| format!("STORAGE_ERROR: {e}"))?;
+    tokio::fs::rename(&tmp, &dest)
+        .await
+        .map_err(|e| format!("STORAGE_ERROR: {e}"))?;
+
+    let size_bytes = dest.metadata().map(|m| m.len()).unwrap_or(0);
+    Ok(ImportModelResult { filename, size_bytes })
+}
+
+#[tauri::command]
+pub fn delete_custom_model(app: tauri::AppHandle, filename: String) -> Result<(), String> {
+    let dest = custom_model_path(&app, &filename)?;
+    if dest.exists() {
+        std::fs::remove_file(&dest).map_err(|e| format!("STORAGE_ERROR: {e}"))?;
+    }
+    Ok(())
+}
+
 #[tauri::command]
 pub fn save_transcription_key(provider: String, value: String) -> Result<(), String> {
     keychain::save_transcription_key(&provider, &value)
@@ -449,4 +585,71 @@ pub fn model_path(app: &tauri::AppHandle, size: &str) -> Result<PathBuf, String>
         .app_data_dir()
         .map(|p| p.join("models").join(format!("ggml-{size}.bin")))
         .map_err(|e| format!("STORAGE_ERROR: {e}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+
+    #[test]
+    fn sanitise_accepts_normal_basename() {
+        assert_eq!(sanitise_model_filename("my-model.bin").unwrap(), "my-model.bin");
+        assert_eq!(sanitise_model_filename("ggml-large-v3.bin").unwrap(), "ggml-large-v3.bin");
+        assert_eq!(sanitise_model_filename("German_Fine_Tune.BIN").unwrap(), "German_Fine_Tune.bin");
+    }
+
+    #[test]
+    fn sanitise_rejects_path_components() {
+        assert!(sanitise_model_filename("../escape.bin").is_err());
+        assert!(sanitise_model_filename("dir/model.bin").is_err());
+        assert!(sanitise_model_filename("dir\\model.bin").is_err());
+    }
+
+    #[test]
+    fn sanitise_rejects_non_bin() {
+        assert!(sanitise_model_filename("model.txt").is_err());
+        assert!(sanitise_model_filename("model").is_err());
+        assert!(sanitise_model_filename(".bin").is_err());
+    }
+
+    #[test]
+    fn sanitise_rejects_windows_reserved_chars() {
+        assert!(sanitise_model_filename("a:b.bin").is_err());
+        assert!(sanitise_model_filename("a*b.bin").is_err());
+        assert!(sanitise_model_filename("a?b.bin").is_err());
+        assert!(sanitise_model_filename("a|b.bin").is_err());
+    }
+
+    fn write_temp(bytes: &[u8]) -> tempfile::NamedTempFile {
+        let mut f = tempfile::NamedTempFile::new().unwrap();
+        f.write_all(bytes).unwrap();
+        f
+    }
+
+    #[test]
+    fn magic_accepts_ggml_header() {
+        let f = write_temp(b"ggml\0\0\0\0extra bytes");
+        assert!(validate_whisper_model_magic(f.path()).is_ok());
+    }
+
+    #[test]
+    fn magic_accepts_gguf_header() {
+        let f = write_temp(b"GGUF\0\0\0\0extra bytes");
+        assert!(validate_whisper_model_magic(f.path()).is_ok());
+    }
+
+    #[test]
+    fn magic_rejects_garbage() {
+        let f = write_temp(b"not a model file at all");
+        let err = validate_whisper_model_magic(f.path()).unwrap_err();
+        assert!(err.contains("INVALID_MODEL"));
+    }
+
+    #[test]
+    fn magic_rejects_too_short_file() {
+        let f = write_temp(b"gg");
+        let err = validate_whisper_model_magic(f.path()).unwrap_err();
+        assert!(err.contains("INVALID_MODEL"));
+    }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -87,6 +87,7 @@ pub fn run() {
     tauri::Builder::default()
         .plugin(tauri_plugin_shell::init())
         .plugin(tauri_plugin_notification::init())
+        .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_autostart::init(tauri_plugin_autostart::MacosLauncher::LaunchAgent, None))
         .plugin(tauri_plugin_process::init())
         .plugin(tauri_plugin_updater::Builder::new().build())
@@ -256,6 +257,9 @@ pub fn run() {
             commands::download_model,
             commands::delete_model,
             commands::cancel_model_download,
+            commands::list_custom_models,
+            commands::import_custom_model,
+            commands::delete_custom_model,
             commands::get_prompts,
             commands::save_prompts,
             commands::save_transcription_key,

--- a/src-tauri/src/transcription/mod.rs
+++ b/src-tauri/src/transcription/mod.rs
@@ -161,7 +161,14 @@ async fn transcribe_local(
         .as_str()
         .unwrap_or("base")
         .to_owned();
-    let model_path = crate::commands::model_path(app, &model_size)?;
+    // Built-in size keywords live under models/ggml-{size}.bin; anything
+    // else is a user-imported file under models/custom/<filename>.
+    let is_builtin = matches!(model_size.as_str(), "tiny" | "base" | "small" | "medium");
+    let model_path = if is_builtin {
+        crate::commands::model_path(app, &model_size)?
+    } else {
+        crate::commands::custom_model_path(app, &model_size)?
+    };
 
     if !model_path.exists() {
         crate::errors::emit(

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -267,6 +267,19 @@
         "elevenlabs": "ElevenLabs",
         "gemini": "Gemini",
         "custom": "Benutzerdefiniert"
+      },
+      "customModel": {
+        "heading": "Eigene Modelle",
+        "import": "Importieren…",
+        "importing": "Importiere…",
+        "empty": "Noch keine eigenen Modelle. Ziehe eine .bin-Datei hierher oder klicke auf Importieren.",
+        "remove": "Entfernen",
+        "deleteTitle": "Eigenes Modell entfernen?",
+        "deleteBody": "„{{name}}\" aus deinen eigenen Modellen entfernen? Die Datei wird vom Speicher gelöscht.",
+        "overwriteTitle": "Datei existiert bereits",
+        "overwriteBody": "Ein eigenes Modell mit diesem Namen existiert bereits. Überschreiben?",
+        "invalidTitle": "Import fehlgeschlagen",
+        "invalidBody": "Diese Datei sieht nicht wie ein whisper.cpp-Modell (.bin) aus."
       }
     },
     "shortcut": {

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -267,6 +267,19 @@
         "elevenlabs": "ElevenLabs",
         "gemini": "Gemini",
         "custom": "Custom"
+      },
+      "customModel": {
+        "heading": "Custom models",
+        "import": "Import…",
+        "importing": "Importing…",
+        "empty": "No custom models yet. Drop a .bin file here or click Import.",
+        "remove": "Remove",
+        "deleteTitle": "Remove custom model?",
+        "deleteBody": "Remove \"{{name}}\" from your custom models? The file will be deleted from disk.",
+        "overwriteTitle": "File already exists",
+        "overwriteBody": "A custom model with this name already exists. Overwrite it?",
+        "invalidTitle": "Import failed",
+        "invalidBody": "This file does not look like a whisper.cpp model (.bin)."
       }
     },
     "shortcut": {

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -267,6 +267,19 @@
         "elevenlabs": "ElevenLabs",
         "gemini": "Gemini",
         "custom": "Personalizado"
+      },
+      "customModel": {
+        "heading": "Modelos personalizados",
+        "import": "Importar…",
+        "importing": "Importando…",
+        "empty": "Aún no hay modelos personalizados. Arrastra un archivo .bin aquí o haz clic en Importar.",
+        "remove": "Eliminar",
+        "deleteTitle": "¿Eliminar modelo personalizado?",
+        "deleteBody": "¿Eliminar \"{{name}}\" de tus modelos personalizados? El archivo se borrará del disco.",
+        "overwriteTitle": "El archivo ya existe",
+        "overwriteBody": "Ya existe un modelo personalizado con este nombre. ¿Sobrescribirlo?",
+        "invalidTitle": "Importación fallida",
+        "invalidBody": "Este archivo no parece ser un modelo de whisper.cpp (.bin)."
       }
     },
     "shortcut": {

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -267,6 +267,19 @@
         "elevenlabs": "ElevenLabs",
         "gemini": "Gemini",
         "custom": "Personnalisé"
+      },
+      "customModel": {
+        "heading": "Modèles personnalisés",
+        "import": "Importer…",
+        "importing": "Importation…",
+        "empty": "Aucun modèle personnalisé pour l'instant. Glissez un fichier .bin ici ou cliquez sur Importer.",
+        "remove": "Supprimer",
+        "deleteTitle": "Supprimer le modèle personnalisé ?",
+        "deleteBody": "Supprimer « {{name}} » de vos modèles personnalisés ? Le fichier sera supprimé du disque.",
+        "overwriteTitle": "Le fichier existe déjà",
+        "overwriteBody": "Un modèle personnalisé portant ce nom existe déjà. Voulez-vous l'écraser ?",
+        "invalidTitle": "Échec de l'importation",
+        "invalidBody": "Ce fichier ne ressemble pas à un modèle whisper.cpp (.bin)."
       }
     },
     "shortcut": {

--- a/src/i18n/locales/it.json
+++ b/src/i18n/locales/it.json
@@ -267,6 +267,19 @@
         "elevenlabs": "ElevenLabs",
         "gemini": "Gemini",
         "custom": "Personalizzato"
+      },
+      "customModel": {
+        "heading": "Modelli personalizzati",
+        "import": "Importa…",
+        "importing": "Importazione…",
+        "empty": "Nessun modello personalizzato. Trascina qui un file .bin oppure clicca su Importa.",
+        "remove": "Rimuovi",
+        "deleteTitle": "Rimuovere il modello personalizzato?",
+        "deleteBody": "Rimuovere \"{{name}}\" dai modelli personalizzati? Il file verrà eliminato dal disco.",
+        "overwriteTitle": "Il file esiste già",
+        "overwriteBody": "Esiste già un modello personalizzato con questo nome. Sovrascriverlo?",
+        "invalidTitle": "Importazione fallita",
+        "invalidBody": "Questo file non sembra un modello whisper.cpp (.bin)."
       }
     },
     "shortcut": {

--- a/src/i18n/locales/pt.json
+++ b/src/i18n/locales/pt.json
@@ -267,6 +267,19 @@
         "elevenlabs": "ElevenLabs",
         "gemini": "Gemini",
         "custom": "Personalizado"
+      },
+      "customModel": {
+        "heading": "Modelos personalizados",
+        "import": "Importar…",
+        "importing": "Importando…",
+        "empty": "Ainda não há modelos personalizados. Solte um arquivo .bin aqui ou clique em Importar.",
+        "remove": "Remover",
+        "deleteTitle": "Remover modelo personalizado?",
+        "deleteBody": "Remover \"{{name}}\" dos seus modelos personalizados? O arquivo será excluído do disco.",
+        "overwriteTitle": "O arquivo já existe",
+        "overwriteBody": "Já existe um modelo personalizado com este nome. Sobrescrever?",
+        "invalidTitle": "Falha na importação",
+        "invalidBody": "Este arquivo não parece ser um modelo whisper.cpp (.bin)."
       }
     },
     "shortcut": {

--- a/src/pages/settings/TranscriptionSettings.tsx
+++ b/src/pages/settings/TranscriptionSettings.tsx
@@ -2,7 +2,8 @@ import { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { invoke } from '@tauri-apps/api/core'
 import { listen } from '@tauri-apps/api/event'
-import { open } from '@tauri-apps/plugin-shell'
+import { open as openExternal } from '@tauri-apps/plugin-shell'
+import { open as openFileDialog, ask, message } from '@tauri-apps/plugin-dialog'
 import { SettingRow } from '../../components/settings/SettingRow'
 import { TRANSCRIPTION_LANGUAGES } from '../../types'
 import type { Settings, TranscriptionLanguage } from '../../types'
@@ -107,6 +108,11 @@ interface DownloadProgress {
   total_bytes: number
 }
 
+interface CustomModelInfo {
+  filename: string
+  size_bytes: number
+}
+
 const MODEL_SIZES: { value: ModelSize; label: string; approxMb: number }[] = [
   { value: 'tiny', label: 'Tiny', approxMb: 75 },
   { value: 'base', label: 'Base', approxMb: 142 },
@@ -128,6 +134,9 @@ export function TranscriptionSettings({ settings, onChange }: Props) {
   const [downloadProgress, setDownloadProgress] = useState<DownloadProgress | null>(null)
   const [providerKey, setProviderKey] = useState('')
   const [keyDirty, setKeyDirty] = useState(false)
+  const [customModels, setCustomModels] = useState<CustomModelInfo[]>([])
+  const [importing, setImporting] = useState(false)
+  const [dragOver, setDragOver] = useState(false)
 
   useEffect(() => {
     MODEL_SIZES.forEach(({ value }) => {
@@ -135,6 +144,19 @@ export function TranscriptionSettings({ settings, onChange }: Props) {
         .then((status) => setModelStatuses((prev) => ({ ...prev, [value]: status })))
         .catch(() => {})
     })
+  }, [])
+
+  async function refreshCustomModels() {
+    try {
+      const list = await invoke<CustomModelInfo[]>('list_custom_models')
+      setCustomModels(list)
+    } catch (e) {
+      console.error('list_custom_models failed:', e)
+    }
+  }
+
+  useEffect(() => {
+    refreshCustomModels()
   }, [])
 
   useEffect(() => {
@@ -151,6 +173,26 @@ export function TranscriptionSettings({ settings, onChange }: Props) {
     })
     return () => { unlisten.then((fn) => fn()) }
   }, [])
+
+  useEffect(() => {
+    if (!isLocal) return
+    const unlistens: Array<Promise<() => void>> = []
+    unlistens.push(listen('tauri://drag-enter', () => setDragOver(true)))
+    unlistens.push(listen('tauri://drag-leave', () => setDragOver(false)))
+    unlistens.push(
+      listen<{ paths: string[] }>('tauri://drag-drop', async (event) => {
+        setDragOver(false)
+        const binPaths = event.payload.paths.filter((p) => p.toLowerCase().endsWith('.bin'))
+        for (const path of binPaths) {
+          await importPath(path)
+        }
+      }),
+    )
+    return () => {
+      unlistens.forEach((p) => p.then((fn) => fn()))
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isLocal])
 
   function handleProviderChange(provider: CloudProvider) {
     onChange({
@@ -178,8 +220,75 @@ export function TranscriptionSettings({ settings, onChange }: Props) {
     onChange({ ...settings, transcription: { ...settings.transcription, muteOtherAudio: next } })
   }
 
-  function handleModelSizeChange(size: ModelSize) {
+  function handleModelSizeChange(size: string) {
     onChange({ ...settings, transcription: { ...settings.transcription, localModelSize: size } })
+  }
+
+  async function importPath(path: string) {
+    setImporting(true)
+    try {
+      await invoke('import_custom_model', { sourcePath: path, overwrite: false })
+      await refreshCustomModels()
+    } catch (err) {
+      const msg = String(err)
+      if (msg.includes('MODEL_ALREADY_EXISTS')) {
+        const confirmed = await ask(t('settings.transcription.customModel.overwriteBody'), {
+          title: t('settings.transcription.customModel.overwriteTitle'),
+          kind: 'warning',
+        })
+        if (confirmed) {
+          try {
+            await invoke('import_custom_model', { sourcePath: path, overwrite: true })
+            await refreshCustomModels()
+          } catch (e2) {
+            console.error('Import (overwrite) failed:', e2)
+          }
+        }
+      } else if (msg.includes('INVALID_MODEL')) {
+        await message(t('settings.transcription.customModel.invalidBody'), {
+          title: t('settings.transcription.customModel.invalidTitle'),
+          kind: 'error',
+        })
+      } else {
+        console.error('Import failed:', err)
+      }
+    } finally {
+      setImporting(false)
+    }
+  }
+
+  async function handleImportClick() {
+    if (importing) return
+    const selected = await openFileDialog({
+      multiple: false,
+      filters: [{ name: 'Whisper model', extensions: ['bin'] }],
+    })
+    if (typeof selected === 'string') {
+      await importPath(selected)
+    }
+  }
+
+  async function handleDeleteCustom(filename: string) {
+    const confirmed = await ask(
+      t('settings.transcription.customModel.deleteBody', { name: filename }),
+      {
+        title: t('settings.transcription.customModel.deleteTitle'),
+        kind: 'warning',
+      },
+    )
+    if (!confirmed) return
+    try {
+      await invoke('delete_custom_model', { filename })
+      await refreshCustomModels()
+      if (selectedSize === filename) {
+        onChange({
+          ...settings,
+          transcription: { ...settings.transcription, localModelSize: 'base' },
+        })
+      }
+    } catch (e) {
+      console.error('Delete custom model failed:', e)
+    }
   }
 
   async function handleDownload(size: ModelSize) {
@@ -324,7 +433,7 @@ export function TranscriptionSettings({ settings, onChange }: Props) {
               <div className="flex flex-col gap-1.5 w-full max-w-xs">
                 {providerMeta.keyLink && (
                   <button
-                    onClick={() => open(providerMeta.keyLink!)}
+                    onClick={() => openExternal(providerMeta.keyLink!)}
                     className="flex items-center justify-center gap-1 px-2.5 py-1.5 text-xs border border-accent/40 text-accent rounded-lg hover:bg-accent-subtle transition-colors"
                   >
                     Get API key for {providerMeta.label} <ExternalLinkIcon />
@@ -349,7 +458,11 @@ export function TranscriptionSettings({ settings, onChange }: Props) {
           label={t('settings.transcription.localModel')}
           description={t('settings.transcription.localModelDescription')}
         >
-          <div className="space-y-3">
+          <div
+            className={`space-y-3 rounded-lg transition-all ${
+              dragOver ? 'ring-2 ring-accent ring-offset-2 ring-offset-bg' : ''
+            }`}
+          >
             <div className="space-y-1">
               {MODEL_SIZES.map(({ value, label, approxMb }) => {
                 const status = modelStatuses[value]
@@ -421,6 +534,69 @@ export function TranscriptionSettings({ settings, onChange }: Props) {
                   </div>
                 )
               })}
+            </div>
+
+            <div className="space-y-1 pt-3 border-t border-border">
+              <div className="flex items-center justify-between pb-1.5">
+                <span className="text-xs text-text-muted uppercase tracking-wide">
+                  {t('settings.transcription.customModel.heading')}
+                </span>
+                <button
+                  onClick={handleImportClick}
+                  disabled={importing}
+                  className="text-xs px-2 py-1 border border-border rounded hover:border-border-hover text-text-muted hover:text-text disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
+                >
+                  {importing
+                    ? t('settings.transcription.customModel.importing')
+                    : t('settings.transcription.customModel.import')}
+                </button>
+              </div>
+
+              {customModels.length === 0 ? (
+                <div className="text-xs text-text-muted px-3 py-4 text-center border border-dashed border-border rounded-lg">
+                  {t('settings.transcription.customModel.empty')}
+                </div>
+              ) : (
+                customModels.map((m) => {
+                  const isSelected = selectedSize === m.filename
+                  return (
+                    <div
+                      key={m.filename}
+                      className={`flex items-center justify-between px-3 py-2 rounded-lg border transition-colors cursor-pointer ${
+                        isSelected
+                          ? 'border-accent bg-accent-subtle'
+                          : 'border-border hover:border-border-hover'
+                      }`}
+                      onClick={() => handleModelSizeChange(m.filename)}
+                    >
+                      <div className="flex items-center gap-2 min-w-0">
+                        <span
+                          className={`w-3 h-3 rounded-full border-2 flex-shrink-0 ${
+                            isSelected ? 'border-accent bg-accent' : 'border-border'
+                          }`}
+                        />
+                        <span className="text-sm text-text font-medium truncate" title={m.filename}>
+                          {m.filename}
+                        </span>
+                        <span className="text-xs text-text-muted flex-shrink-0">
+                          {formatBytes(m.size_bytes)}
+                        </span>
+                      </div>
+                      <div className="flex items-center gap-2">
+                        <button
+                          onClick={(e) => {
+                            e.stopPropagation()
+                            handleDeleteCustom(m.filename)
+                          }}
+                          className="text-xs px-2 py-1 border border-border rounded hover:border-red-500/50 text-text-muted hover:text-red-500 transition-colors"
+                        >
+                          {t('settings.transcription.customModel.remove')}
+                        </button>
+                      </div>
+                    </div>
+                  )
+                })
+              )}
             </div>
           </div>
         </SettingRow>

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -33,7 +33,9 @@ export interface AIPrompt {
 export interface Settings {
   transcription: {
     mode: 'cloud' | 'local'
-    localModelSize: 'tiny' | 'base' | 'small' | 'medium'
+    // Built-in sizes are 'tiny' | 'base' | 'small' | 'medium'; any other
+    // string identifies a user-imported model file under app_data/models/custom/.
+    localModelSize: string
     cloudProvider: 'openai' | 'groq' | 'deepgram' | 'elevenlabs' | 'gemini' | 'custom'
     cloudModel: string
     cloudCustomEndpoint: string


### PR DESCRIPTION
  Adds the ability to import user-supplied `.bin` Whisper models (whisper.cpp compatible) and use them alongside the built-in tiny / base / small / medium downloads. Imported models live under
  `$APPDATA/models/custom/` and appear in their own section below the built-in list.

  ## Highlights

  - **Import** via native file picker (tauri-plugin-dialog) *or* drag-and-drop a `.bin` file onto the settings panel — the drop zone shows a focus ring while a drag is in progress.
  - **Magic-byte validation** on import: only files starting with `ggml` (legacy) or `GGUF` (newer format) are accepted, so dropping random files in does not crash whisper-rs at inference time.
  - **Confirm dialogs** for both destructive flows: re-importing a same-name file prompts to overwrite; removing a custom model prompts before unlinking.
  - **Atomic copy** (stage to `*.bin.tmp` then rename) so an interrupted multi-GB transfer never leaves a partial entry in the list.
  - **Filename sanitisation** rejects path components, hidden files, and Windows-reserved characters before they ever hit disk.

  ## Files

  - `src-tauri/src/commands/mod.rs` — `list_custom_models`, `import_custom_model`, `delete_custom_model` commands + helpers, with unit tests for the two pure functions (magic-bytes, sanitiser).
  - `src-tauri/src/transcription/mod.rs` — inference dispatch routes built-in keywords to `ggml-{size}.bin` and everything else through `custom_model_path`.
  - `src/pages/settings/TranscriptionSettings.tsx` — new Custom Models section with empty-state hint, per-row Remove, Import button, and window-level drag-drop listener.
  - `tauri-plugin-dialog` added to capabilities, npm + Cargo deps, plus the resync of `Cargo.lock`.
  - `customModel` block added to all six locales.
  
  ## Test plan
  
  - [ ] Settings → Transcription → Local: built-in tiny/base/small/medium still download, delete, and select as before
  - [ ] Import a real ggml-format `.bin` via the Import button → appears in list, selects, transcribes
  - [ ] Drag-and-drop a `.bin` onto the panel → same result; non-.bin drops are ignored
  - [ ] Re-import a file with the same name → overwrite-confirm appears, both buttons behave
  - [ ] Remove a custom model → confirm appears; the file disappears from disk; if it was selected, selection falls back to `base`
  - [ ] Drop a random binary (non-Whisper) → validation error dialog, nothing copied
  - [ ] DE / EN locale switch shows the new strings correctly
  
  Closes #7