### PR TITLE
fix(ui): cap main pad at 1200px, add breathe modifier for list pages

### DIFF
--- a/src/components/settings/SettingRow.tsx
+++ b/src/components/settings/SettingRow.tsx
@@ -9,10 +9,10 @@ interface SettingRowProps {
 export function SettingRow({ label, description, children }: SettingRowProps) {
   return (
     <div className="flex items-center justify-between py-3 border-b border-border last:border-0">
-      <div className="flex-1 mr-8">
+      <div className="flex-1 mr-8 min-w-0">
         <p className="text-sm font-medium text-text">{label}</p>
         {description && (
-          <p className="text-xs text-text-muted mt-0.5">{description}</p>
+          <p className="text-xs text-text-muted mt-0.5 max-w-[60ch]">{description}</p>
         )}
       </div>
       <div className="flex-shrink-0">{children}</div>

--- a/src/index.css
+++ b/src/index.css
@@ -347,7 +347,15 @@ input[type="password"]::-ms-reveal { display: none; }
 .shell-foot .lbl { font-family: var(--f-mono); font-size: 10.5px; letter-spacing: 0.1em; text-transform: uppercase; color: var(--v-ink-3); flex-shrink: 0; }
 .shell-foot .shortcut-badge { margin-left: auto; min-width: 0; font-family: var(--f-mono); font-size: 10px; color: var(--v-ink-2); background: var(--v-bg); padding: 2px 6px; border-radius: var(--r-1); border: 1px solid var(--v-line-soft); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .shell-main { flex: 1; overflow-y: auto; background: var(--v-surface); }
-.shell-main-pad { padding: 32px 44px 44px; max-width: 720px; margin: 0 auto; }
+/* Default page width — regime A from #70. The cap framing on wider
+   windows is intentional; without it, content stays at its native
+   ~720px and looks stranded on big monitors. */
+.shell-main-pad { padding: 32px 44px 44px; max-width: 1200px; margin: 0 auto; }
+/* Regime B from #70 — applied on list-heavy pages (History, Snippets,
+   Dictionary, Fillers) so the extra horizontal space actually carries
+   content (more chips per row, less truncated transcript lines) rather
+   than being framed away. */
+.shell-main-pad.breathe { max-width: 1600px; }
 
 /* ============================================================
    Status Pill

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -19,6 +19,11 @@ import { formatShortcut } from '../shortcut/format'
 type NavId = 'history' | 'stats' | 'transcription' | 'ai' | 'snippets' | 'dictionary' | 'fillers' | 'general' | 'about' | 'legal'
 type LegalTab = 'privacy' | 'terms'
 
+// Pages whose content benefits from the wider regime-B layout. List-heavy
+// pages get more chips/rows per line; the others stay at the 1200 cap so
+// SettingRow descriptions and form copy remain readable.
+const BREATHE_PAGES: ReadonlySet<NavId> = new Set(['history', 'snippets', 'dictionary', 'fillers'])
+
 interface Props {
   settings: Settings
   onSave: (updated: Settings) => Promise<void>
@@ -122,7 +127,7 @@ export function SettingsPage({ settings, onSave }: Props) {
       </aside>
 
       <main className="shell-main">
-        <div className="shell-main-pad">
+        <div className={`shell-main-pad${BREATHE_PAGES.has(active) ? ' breathe' : ''}`}>
           {error && (
             <div style={{ marginBottom: 20, padding: '12px 16px', borderRadius: 'var(--r-2)', background: 'var(--v-accent-soft)', border: '1px solid var(--v-danger)', color: 'var(--v-danger)', fontFamily: 'var(--f-mono)', fontSize: 12 }}>
               {t(`errors.${camelCode(error.code)}`, error.message)}


### PR DESCRIPTION
  The shell main-pad had `max-width: 720px`, so even on a maximized window the content stayed at the native settings-page width and read as stranded in the middle of a sea of empty surface. Root cause was a
  single CSS line that's been there since the initial layout.

  ## Regime A — default

  Bumps `.shell-main-pad` `max-width` to **1200px**. Form-heavy pages (Transcription, AI, General, Stats, About, Legal) keep a readable line length and gain intentional framing on wider windows instead of
  unintentional whitespace.

  ## Regime B — list-heavy pages

  Adds `.shell-main-pad.breathe` at **1600px**, applied via a `BREATHE_PAGES` set in `SettingsPage.tsx` when the active section is one of:
  - **Snippets** — output text truncates less
  - **Dictionary** — more chips per row
  - **Fillers** — same chip layout as Dictionary

  ## SettingRow
  
  `description` gets `max-w-[60ch]` (and the wrapping div gets `min-w-0`) so descriptions still wrap at a comfortable reading width on the now-wider regime-A pages, instead of stretching across.
  
  ## Test plan
  
  - [ ] At default 1080×720: layout identical to before
  - [ ] At the 800×580 minimum: layout identical to before (windows smaller than the cap aren't affected)
  - [ ] Maximized on a 1920+ monitor: form pages frame at 1200, no stranding
  - [ ] Maximized on a 1920+ monitor: History / Snippets / Dictionary / Fillers frame at 1600 and visibly use more horizontal space
  - [ ] SettingRow descriptions wrap at ~60 chars on the widened pages

  Closes #70