### PR TITLE
chore: bump version to 0.3.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "voca",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "voca",
-      "version": "0.3.3",
+      "version": "0.3.4",
       "dependencies": {
         "@tauri-apps/api": "^2.0.0",
         "@tauri-apps/plugin-dialog": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "voca",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -6576,7 +6576,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "voca"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "arboard",
  "base64 0.22.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "voca"
-version = "0.3.3"
+version = "0.3.4"
 description = "VOCA – Speech-to-Text Desktop App"
 authors = []
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "VOCA",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "identifier": "app.voca",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
  Version bump for the v0.3.4 release. All four bundle issues (#64, #7, #8, #70) have landed on develop since v0.3.3; this PR is the final step before the tag.

  ## What v0.3.4 contains (vs v0.3.3)
  
  - **#64** — CI trigger dedup, halves PR check-row noise
  - **#7** — Custom local Whisper model import (file picker, drag-drop, magic-byte validation, `app_data/models/custom/` subdir)
  - **#8** — Silence trim (default ON) and opt-in auto-stop, both via Silero VAD; expect a meaningful installer-size jump from the bundled ONNX runtime
  - **#70** — Main window no longer looks stranded when maximized; regime A capped at 1200px, regime B at 1600px on list-heavy pages

  ## Release significance
  
  - First version that actually exercises the auto-updater end-to-end. Users on v0.3.3 should see the update-toast / About-page "available" branch — both untested paths from the v0.3.3 ship notes.
  - Confirms the signed `.exe.sig` + `latest.json` pipeline works on a real second release.